### PR TITLE
Copy across topic communities

### DIFF
--- a/app/helpers/service_manual_topic_helper.rb
+++ b/app/helpers/service_manual_topic_helper.rb
@@ -1,0 +1,9 @@
+module ServiceManualTopicHelper
+  def service_manual_topic_related_communities_title(communities)
+    if communities.length == 1
+      "Join the #{communities.first[:title]}"
+    else
+      "Join the community"
+    end
+  end
+end

--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -41,9 +41,11 @@
   <div class="column-third">
     <% if @content_item.content_owners.any? %>
       <aside class="related">
-        <h2 class="related__title" id="related-communities">Join the conversation</h2>
+        <h2 class="related__title" id="related-communities">
+          <%= service_manual_topic_related_communities_title(@content_item.content_owners) -%>
+        </h2>
         <p class="related__description">
-          Discuss the work you're doing with other service teams across government.
+          Find out what the cross-government community does and how to get involved.
         </p>
         <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
           <ul class="related__list">

--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -45,11 +45,11 @@
         <p class="related__description">
           Discuss the work you're doing with other service teams across government.
         </p>
-        <nav role="navigation" aria-labelledby="related-communities">
+        <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
           <ul class="related__list">
             <% @content_item.content_owners.each do |content_owner| %>
               <li class="related__list-item">
-                <%= link_to @content_owner.title, @content_owner.href %>
+                <%= link_to content_owner.title, content_owner.href %>
               </li>
             <% end %>
           </ul>

--- a/test/helpers/service_manual_topic_helper_test.rb
+++ b/test/helpers/service_manual_topic_helper_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ServiceManualTopicHelperTest < ActionView::TestCase
+  test "service_manual_topic_related_communities_title invites you to join the only related community" do
+    communities = [{ title: "Agile delivery community" }]
+
+    assert_equal "Join the Agile delivery community",
+      service_manual_topic_related_communities_title(communities)
+  end
+
+  test "service_manual_topic_related_communities_title invites you to join the community as a " \
+    "whole if there are multiple communities" do
+    communities = [{ title: "Agile delivery community" }, { title: "User research community" }]
+
+    assert_equal "Join the community",
+      service_manual_topic_related_communities_title(communities)
+  end
+end

--- a/test/integration/service_manual_topic_test.rb
+++ b/test/integration/service_manual_topic_test.rb
@@ -28,4 +28,15 @@ class ServiceManualTopicTest < ActionDispatch::IntegrationTest
 
     refute page.has_css?('meta[name="description"]', visible: false)
   end
+
+  test "it lists communities in the sidebar" do
+    setup_and_visit_content_item('service_manual_topic')
+
+    within('.related-communities') do
+      assert page.has_link?("Agile delivery community",
+        href: "/service-manual/communities/agile-delivery-community")
+      assert page.has_link?("User research community",
+        href: "/service-manual/communities/user-research-community")
+    end
+  end
 end


### PR DESCRIPTION
We have implemented communities in the topic sidebar on government-frontend. This cherry picks the relevant commits across.