### PR TITLE
Update the govuk frontend toolkit to 4.10.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby File.read(".ruby-version").strip
 
 gem 'airbrake', '4.0'
-gem 'govuk_frontend_toolkit', '2.0.1'
+gem 'govuk_frontend_toolkit', '4.10.0'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'
 gem 'rails', '4.1.14.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     govuk-lint (0.6.1)
       rubocop (~> 0.35.0)
       scss_lint (~> 0.44.0)
-    govuk_frontend_toolkit (2.0.1)
+    govuk_frontend_toolkit (4.10.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     http-cookie (1.0.2)
@@ -238,7 +238,7 @@ DEPENDENCIES
   gds-api-adapters (= 27.0.0)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
-  govuk_frontend_toolkit (= 2.0.1)
+  govuk_frontend_toolkit (= 4.10.0)
   jasmine-rails
   logstasher (= 0.6.1)
   phantomjs (~> 1.9.7)


### PR DESCRIPTION
Use the latest version of the govuk frontend toolkit.

This won't affect any govuk components, e.g. the phase banner or breadcrumb, updating these will require alphagov/static to be updated.

--

https://github.com/alphagov/govuk_frontend_toolkit/blob/master/CHANGELOG.md

# 4.10.0

- Allow New Transport font stack to be overridden by apps using
`$toolkit-font-stack`
and `$toolkit-font-stack-tabular` (PR #230)

# 4.9.1

- Fix phase banner alignment (PR #266)

# 4.9.0

- Add websafe organisation colours
- Split colours into two files with backwards-compatible colours.scss
replacement

# 4.8.2

- Add GOV.UK lint to lint scss files (PR #260)
- Remove reference to old colour palette (PR #256)
- Fix link to GOV.UK elements - tabular data

# 4.8.1

- Update DEFRA brand colour to new green (PR #249)

# 4.8.0

- Pass cohort name to analytics when using multivariate test (PR #251)

# 4.7.0

- Add 'mailto' tracking to GOV.UK Analytics (PR #244)

# 4.6.1

- Use the Sass variable $light-blue for link active and hover colours
(PR #242)

# 4.6.0

- Add breadcrumb styles, separator images and documentation (PR #236)
- Add fallback image for the back link (PR #235)

# 4.5.0

- Find and auto-start JavaScript modules from markup:
`data-module="module-name"`(PR #227)

# 4.4.0

- Add helpers partial for functions
- Add px to em function and documentation

# 4.3.0

- Allow javascript error tracking to be filtered to avoid noise from
plugins

# 4.2.1

- Track download links using events not pageviews

# 4.2.0

- Add two analytics plugins for download and external link tracking
- Update typography mixins to be mobile first (PR #157)

# 4.1.1

- Update Accessible Media Player to remove dependency on $.browser (PR
#206)

# 4.1.0

- Add support for sending the `page` option to
`GOVUK.analytics.trackEvent` (PR #203)

# 4.0.1

- Fix: stop multiline text from dropping below phase tag.

# 4.0.0

- Remove Google Analytics classic
https://github.com/alphagov/govuk_frontend_toolkit/pull/194
  - References to google-analytics-classic-tracker.js should be removed
- Rename GOVUK.Tracker to GOVUK.Analytics
  - References to GOVUK.Tracker should be updated

# 3.5.1

- Changes Analytics API library to accept one, both or neither of the
analytics tracking codes. This means we can start removing classic
tracking codes from apps.

#3.5.0

- Adds cross domain tracking to Analytics API library:
https://github.com/alphagov/govuk_frontend_toolkit/pull/185
- Adds sass variables for discovery and live phases

#3.4.2

- Fix: Before this fix, when a user fell into variant 0 of a
multivariate test,
the data wouldn't be reported to Google correctly because of a broken
null check in the code block that opts the user into the Google Content
Experiment.

# 3.4.1

- Fix: Make the error colour a darker red for greater contrast and to
meet WCAG 2.0 AAAA
(this was meant to go into 3.3.1 but was lost from history)
- Add `$focus-colour` variable (#180)

# 3.4.0

- multivariate-test.js: add support for using Google Content
Experiments as the reporting
backend for multivariate tests

# 3.3.1

- Fix: Make the error colour a darker red for greater contrast and to
meet WCAG 2.0 AAAA

# 3.3.0

- Add: Analytics - pageview tracking for a print attempt

# 3.2.1

- Fix: Analytics - don't run error and print plugins on load

# 3.2.0

- Add: Analytics API
https://github.com/alphagov/govuk_frontend_toolkit/pull/162
https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/anal
ytics.md

# 3.1.0

- Fix: outdent to add right margin rather than only left
- Fix: add missing semi-colons in JavaScript files
- Fix: use box-sizing mixin in column mixin to support more browsers
- Add: ability to specify float direction on column mixin
- Add: Sass-lint tests

# 3.0.1

- Fix a bug with the npm publishing. npm requires a version change to
publish a package.

# 3.0.0

- Change publishing method to not use git submodules in
govuk_frontend_toolkit_npm.
  This is a major version bump because it will move the toolkit from
  `./node_modules/govuk_frontend_toolkit/govuk_frontend_toolkit/`
  to `./node_modules/govuk_frontend_toolkit/`, which will break
relative imports in Sass.
- Fix typo in Sass comment