### PR TITLE
Fix scss lint offence

### DIFF
--- a/app/assets/stylesheets/modules/_page-contents.scss
+++ b/app/assets/stylesheets/modules/_page-contents.scss
@@ -28,6 +28,7 @@
 
   &__list a {
     text-decoration: none;
+
     &:hover,
     &:focus,
     &:active {


### PR DESCRIPTION
Add missing empty line between blocks.

app/assets/stylesheets/modules/_page-contents.scss:31 
[W] EmptyLineBetweenBlocks: Rule declaration should be preceded by an empty
line

cc. @AndrewVos.