### PR TITLE
Display a lede with the guide summary

### DIFF
--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -58,6 +58,10 @@ class ServiceManualGuidePresenter < ContentItemPresenter
     crumbs
   end
 
+  def summary
+    content_item['details']['summary']
+  end
+
 private
 
   def updated_at

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -12,6 +12,12 @@
 
   <div class="column-two-thirds">
     <%= render "govuk_component/title", title: @content_item.title, context: @content_item.main_topic_title %>
+
+    <% if @content_item.summary.present? %>
+      <p class="lede lede--with-bottom-margin">
+        <%= @content_item.summary %>
+      </p>
+    <% end %>
   </div>
 
   <div class="column-third">

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -16,4 +16,18 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
       refute page.has_content?('Published by')
     end
   end
+
+  test "displays a summary if present" do
+    setup_and_visit_content_item('point_page')
+
+    within('.lede') do
+      assert page.has_content?('Research to develop a deep knowledge of who the service users are')
+    end
+  end
+
+  test "the lede is not visible unless there is a summary" do
+    setup_and_visit_content_item('basic_with_related_discussions')
+
+    refute page.has_css?('.lede')
+  end
 end


### PR DESCRIPTION
This is being implemented for the point page that uses the service_manual_guide schema.

(The build will be broken until https://github.com/alphagov/govuk-content-schemas/pull/294 makes it's way in)