### PR TITLE
Optionally collapse topics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'poltergeist'
   gem 'webmock', '~> 1.18.0', require: false
   gem 'govuk-content-schema-test-helpers', '1.1.0'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     casperjs (1.0.0)
+    cliver (0.3.2)
     coderay (1.1.0)
     concurrent-ruby (1.0.0)
     crack (0.4.3)
@@ -117,6 +118,11 @@ GEM
       ast (~> 2.2)
     phantomjs (1.9.8.0)
     plek (1.11.0)
+    poltergeist (1.9.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -214,6 +220,9 @@ GEM
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    websocket-driver (0.6.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     wraith (3.1.0)
       anemone
       casperjs
@@ -243,6 +252,7 @@ DEPENDENCIES
   logstasher (= 0.6.1)
   phantomjs (~> 1.9.7)
   plek (= 1.11)
+  poltergeist
   pry-byebug
   rails (= 4.1.14.1)
   rails-i18n (>= 4.0.4)

--- a/app/assets/stylesheets/modules/_subsections.scss
+++ b/app/assets/stylesheets/modules/_subsections.scss
@@ -29,15 +29,16 @@
 
   &__list {
     @include core-19;
-    padding-left: $gutter-two-thirds;
+    padding-left: 0;
+    list-style-type: none;
   }
 
   &__list-item {
-    margin-bottom: 5px;
+    margin-bottom: 0.5em;
   }
 
   &__list-item a {
-    text-decoration: underline;
+    text-decoration: none;
   }
 }
 
@@ -167,15 +168,6 @@
           padding-top: 5px;
         }
       }
-    }
-
-    &__list {
-      padding-left: 0;
-      list-style-type: none;
-    }
-
-    &__list-item a {
-      text-decoration: none;
     }
 
   }

--- a/app/presenters/service_manual_topic_presenter.rb
+++ b/app/presenters/service_manual_topic_presenter.rb
@@ -9,6 +9,7 @@ class ServiceManualTopicPresenter
     @description = content_item["description"]
     @format = content_item["format"]
     @locale = content_item["locale"]
+    @visually_collapsed = content_item["details"]["visually_collapsed"]
   end
 
   def breadcrumbs
@@ -31,6 +32,10 @@ class ServiceManualTopicPresenter
 
   def phase
     "beta"
+  end
+
+  def visually_collapsed?
+    @visually_collapsed
   end
 
 private

--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -22,7 +22,11 @@
       <%= @content_item.description %>
     </p>
 
-    <div class="js-hidden" data-module="accordion-with-descriptions">
+    <% if @content_item.visually_collapsed? %>
+      <div class="js-hidden" data-module="accordion-with-descriptions">
+    <% else %>
+      <div>
+    <% end %>
       <div class="subsection-wrapper">
 
         <% @content_item.groups.each_with_index do |link_group, idx| %>

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ServiceManualGuideTest < ActionDispatch::IntegrationTest
   test "service manual guide shows content owners" do
-    setup_and_visit_content_item('basic_with_related_discussions')
+    setup_and_visit_example('service_manual_guide', 'basic_with_related_discussions')
 
     within('.metadata') do
       assert page.has_link?('Agile delivery community')
@@ -10,7 +10,7 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
   end
 
   test "service manual guide does not show published by" do
-    setup_and_visit_content_item('service_manual_guide_community')
+    setup_and_visit_example('service_manual_guide', 'service_manual_guide_community')
 
     within('.metadata') do
       refute page.has_content?('Published by')
@@ -18,7 +18,7 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
   end
 
   test "displays a summary if present" do
-    setup_and_visit_content_item('point_page')
+    setup_and_visit_example('service_manual_guide', 'point_page')
 
     within('.lede') do
       assert page.has_content?('Research to develop a deep knowledge of who the service users are')
@@ -26,7 +26,7 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
   end
 
   test "the lede is not visible unless there is a summary" do
-    setup_and_visit_content_item('basic_with_related_discussions')
+    setup_and_visit_example('service_manual_guide', 'basic_with_related_discussions')
 
     refute page.has_css?('.lede')
   end

--- a/test/integration/service_manual_topic_test.rb
+++ b/test/integration/service_manual_topic_test.rb
@@ -39,4 +39,17 @@ class ServiceManualTopicTest < ActionDispatch::IntegrationTest
         href: "/service-manual/communities/user-research-community")
     end
   end
+
+  test "it does not apply the accordion if the topic isn't visually collapsed" do
+    setup_and_visit_content_item('service_manual_topic')
+
+    refute page.has_css?(%{div[data-module="accordion-with-descriptions"]})
+  end
+
+  test "it does apply the accordion if the topic is visually collapsed" do
+    example = get_content_example_by_format_and_name('service_manual_topic', 'service_manual_topic_collapsed')
+    setup_and_visit_content_example(example)
+
+    assert page.has_css?(%{div[data-module="accordion-with-descriptions"]})
+  end
 end

--- a/test/integration/service_manual_topic_test.rb
+++ b/test/integration/service_manual_topic_test.rb
@@ -40,16 +40,20 @@ class ServiceManualTopicTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "it does not apply the accordion if the topic isn't visually collapsed" do
-    setup_and_visit_content_item('service_manual_topic')
+  test "it does not insert the accordion buttons if the topic isn't visually collapsed" do
+    using_javascript_driver do
+      setup_and_visit_content_item('service_manual_topic')
 
-    refute page.has_css?(%{div[data-module="accordion-with-descriptions"]})
+      refute page.has_css?(".subsection__button")
+    end
   end
 
-  test "it does apply the accordion if the topic is visually collapsed" do
-    example = get_content_example_by_format_and_name('service_manual_topic', 'service_manual_topic_collapsed')
-    setup_and_visit_content_example(example)
+  test "it inserts the accordion buttons if the topic is visually collapsed" do
+    using_javascript_driver do
+      example = get_content_example_by_format_and_name('service_manual_topic', 'service_manual_topic_collapsed')
+      setup_and_visit_content_example(example)
 
-    assert page.has_css?(%{div[data-module="accordion-with-descriptions"]})
+      assert page.has_css?(".subsection__button")
+    end
   end
 end

--- a/test/integration/service_manual_topic_test.rb
+++ b/test/integration/service_manual_topic_test.rb
@@ -30,7 +30,7 @@ class ServiceManualTopicTest < ActionDispatch::IntegrationTest
   end
 
   test "it lists communities in the sidebar" do
-    setup_and_visit_content_item('service_manual_topic')
+    setup_and_visit_example('service_manual_topic', 'service_manual_topic')
 
     within('.related-communities') do
       assert page.has_link?("Agile delivery community",
@@ -42,7 +42,7 @@ class ServiceManualTopicTest < ActionDispatch::IntegrationTest
 
   test "it does not insert the accordion buttons if the topic isn't visually collapsed" do
     using_javascript_driver do
-      setup_and_visit_content_item('service_manual_topic')
+      setup_and_visit_example('service_manual_topic', 'service_manual_topic')
 
       refute page.has_css?(".subsection__button")
     end
@@ -50,8 +50,7 @@ class ServiceManualTopicTest < ActionDispatch::IntegrationTest
 
   test "it inserts the accordion buttons if the topic is visually collapsed" do
     using_javascript_driver do
-      example = get_content_example_by_format_and_name('service_manual_topic', 'service_manual_topic_collapsed')
-      setup_and_visit_content_example(example)
+      setup_and_visit_example('service_manual_topic', 'service_manual_topic_collapsed')
 
       assert page.has_css?(".subsection__button")
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,53 +50,6 @@ class ActionDispatch::IntegrationTest
     end
   end
 
-  def assert_has_component_metadata_pair(label, value)
-    within shared_component_selector("metadata") do
-      # Flatten top level / "other" args, for consistent hash access
-      component_args = JSON.parse(page.text).tap do |args|
-        args.merge!(args.delete("other"))
-      end
-      assert_equal value, component_args.fetch(label)
-    end
-  end
-
-  def assert_has_component_title(title)
-    within shared_component_selector("title") do
-      assert_equal title, JSON.parse(page.text).fetch("title")
-    end
-  end
-
-  def assert_has_component_govspeak(content, index: 1)
-    within_component_govspeak(index: index) do
-      assert_equal content, JSON.parse(page.text).fetch("content")
-    end
-  end
-
-  def within_component_govspeak(index: 1)
-    within(shared_component_selector("govspeak") + ":nth-of-type(#{index})") do
-      component_args = JSON.parse(page.text)
-      yield component_args
-    end
-  end
-
-  def assert_has_component_breadcrumbs(breadcrumbs)
-    within shared_component_selector("breadcrumbs") do
-      assert_equal breadcrumbs, JSON.parse(page.text).deep_symbolize_keys.fetch(:breadcrumbs)
-    end
-  end
-
-  def assert_has_contents_list(contents)
-    assert page.has_css?(".dash-list"), "Failed to find an element with a class of dash-list"
-    within ".dash-list" do
-      contents.each do |heading|
-        selector = "a[href=\"##{heading[:id]}\"]"
-        text = heading.fetch(:text)
-        assert page.has_css?(selector), "Failed to find an element matching: #{selector}"
-        assert page.has_css?(selector, text: text), "Failed to find an element matching #{selector} with text: #{text}"
-      end
-    end
-  end
-
   def setup_and_visit_content_item(name)
     example = get_content_example(name)
     setup_and_visit_content_example(example)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,28 +50,15 @@ class ActionDispatch::IntegrationTest
     end
   end
 
-  def setup_and_visit_content_item(name)
-    example = get_content_example(name)
-    setup_and_visit_content_example(example)
-  end
-
-  def setup_and_visit_content_example(example)
+  def setup_and_visit_example(format, name)
+    example = get_content_example_by_format_and_name(format, name)
     base_path = JSON.parse(example).fetch('base_path')
 
     content_store_has_item(base_path, example)
     visit base_path
   end
 
-  def get_content_example(name)
-    get_content_example_by_format_and_name(schema_format, name)
-  end
-
   def get_content_example_by_format_and_name(format, name)
     GovukContentSchemaTestHelpers::Examples.new.get(format, name)
-  end
-
-  # Override this method if your test file doesn't match the convention
-  def schema_format
-    self.class.to_s.gsub('Test', '').underscore
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -103,10 +103,10 @@ class ActionDispatch::IntegrationTest
   end
 
   def setup_and_visit_content_example(example)
-    @content_item = JSON.parse(example).tap do |item|
-      content_store_has_item(item["base_path"], item.to_json)
-      visit item["base_path"]
-    end
+    base_path = JSON.parse(example).fetch('base_path')
+
+    content_store_has_item(base_path, example)
+    visit base_path
   end
 
   def get_content_example(name)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,7 +71,12 @@ class ActionDispatch::IntegrationTest
   end
 
   def setup_and_visit_content_item(name)
-    @content_item = JSON.parse(get_content_example(name)).tap do |item|
+    example = get_content_example(name)
+    setup_and_visit_content_example(example)
+  end
+
+  def setup_and_visit_content_example(example)
+    @content_item = JSON.parse(example).tap do |item|
       content_store_has_item(item["base_path"], item.to_json)
       visit item["base_path"]
     end


### PR DESCRIPTION
We are now allowing the content designers in the publisher to decide whether the accordion is applied or not. There wasn't a clear set of rules that we could define. It seems as though a human needs to decide whether it is collapsed or not.

The default is that the topic sections are expanded. It is more likely that a topic will be collapsed but the downside of a difficult to use topic is more significant than the upside of saving a click in the publisher.