### PR TITLE
[DO NOT MERGE] A working poltergeist test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'poltergeist'
   gem 'webmock', '~> 1.18.0', require: false
   gem 'govuk-content-schema-test-helpers', '1.1.0'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     casperjs (1.0.0)
+    cliver (0.3.2)
     coderay (1.1.0)
     concurrent-ruby (1.0.0)
     crack (0.4.3)
@@ -117,6 +118,11 @@ GEM
       ast (~> 2.2)
     phantomjs (1.9.8.0)
     plek (1.11.0)
+    poltergeist (1.9.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -214,6 +220,9 @@ GEM
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    websocket-driver (0.6.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     wraith (3.1.0)
       anemone
       casperjs
@@ -243,6 +252,7 @@ DEPENDENCIES
   logstasher (= 0.6.1)
   phantomjs (~> 1.9.7)
   plek (= 1.11)
+  poltergeist
   pry-byebug
   rails (= 4.1.14.1)
   rails-i18n (>= 4.0.4)

--- a/test/integration/service_manual_topic_test.rb
+++ b/test/integration/service_manual_topic_test.rb
@@ -41,10 +41,10 @@ class ServiceManualTopicTest < ActionDispatch::IntegrationTest
   end
 
   test "it does not apply the accordion if the topic is visually expanded" do
-    Capybara.current_driver = Capybara.javascript_driver
+    using_javascript_driver do
+      setup_and_visit_content_item('service_manual_topic')
 
-    setup_and_visit_content_item('service_manual_topic')
-
-    assert page.has_css?(".subsection-controls")
+      assert page.has_css?(".subsection-controls")
+    end
   end
 end

--- a/test/integration/service_manual_topic_test.rb
+++ b/test/integration/service_manual_topic_test.rb
@@ -39,4 +39,12 @@ class ServiceManualTopicTest < ActionDispatch::IntegrationTest
         href: "/service-manual/communities/user-research-community")
     end
   end
+
+  test "it does not apply the accordion if the topic is visually expanded" do
+    Capybara.current_driver = Capybara.javascript_driver
+
+    setup_and_visit_content_item('service_manual_topic')
+
+    assert page.has_css?(".subsection-controls")
+  end
 end


### PR DESCRIPTION
When we `require 'slimmer/test'` we override the method that results in a network request to static for the template to stuff everything inside `<div id="wrapper">` into and instead uses a template fixture from slimmer eg. wrapper.html or header_footer_only.html.

These template fixtures include javascript files that are hosted on assets.digital.cabinet-office.gov.uk and therefore require a network request.

Some of the apps including this one, to avoid making requests over the network, have used the following snippet to tell slimmer to not use slimmer unless specified with an environment variable.

```
class ActionController::Base
  before_filter proc {
    response.headers[Slimmer::Headers::SKIP_HEADER] = "true" unless ENV["USE_SLIMMER"]
  }
end
```

Why isn't this snippet always a good idea? When tests need javascript.

jQuery, govuk-template.js and static's application.js are included via the slimmer template. As it stands if your test for example needs jQuery it won't be available unless you:

a) Allow the test to reach a running instance of static by removing `require 'slimmer/text'`.
b) Disable the above snippet so wrapper.html can be used and the externally hosted javascript files pulled in.

https://github.com/alphagov/service-manual-frontend/pull/12/commits/564a276c00bb6a38744281a59d463e14df42eb46 is an implementation of b).