### PR TITLE
Adjust the position of the accordion icon

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -18,7 +18,7 @@
 
       // Wrap each title in a button, with aria controls matching the ID of the subsection
       $subsectionTitle.each(function(index) {
-        $(this).wrapInner( '<button class="subsection__button" aria-expanded="false" aria-controls="subsection_content_' + index +'"></a>' );
+        $(this).wrapInner( '<button class="subsection__button" aria-expanded="false" aria-controls="subsection_content_'+index+'"></button>' );
       });
 
       var $subsectionButton = $element.find('.subsection__button');

--- a/app/assets/stylesheets/modules/_related-content.scss
+++ b/app/assets/stylesheets/modules/_related-content.scss
@@ -1,5 +1,8 @@
 .related {
-  border-top: 1px solid $border-colour;
+  @include media(tablet) {
+    border-top: 1px solid $border-colour;
+  }
+
   padding-top: 1em;
 
   &__title {

--- a/app/assets/stylesheets/modules/_subsections.scss
+++ b/app/assets/stylesheets/modules/_subsections.scss
@@ -77,20 +77,14 @@
 
     &__header {
       position: relative;
-      padding-top: $gutter-half;
-      padding-bottom: $gutter-half;
+      padding-top: 14px;
+      padding-bottom: 12px;
       border-top: 1px solid $border-colour;
 
       // Change the background of the header on hover
       &:hover {
         cursor: pointer;
         background: $highlight-colour;
-      }
-    }
-
-    &--is-open {
-      .subsection__header {
-        padding-bottom: 6px;
       }
     }
 
@@ -123,14 +117,6 @@
       }
     }
 
-    &--is-open {
-      .subsection__description {
-        @include media(tablet) {
-          margin-bottom: $gutter-one-quarter;
-        }
-      }
-    }
-
     &__icon {
       position: absolute;
       top: 50%;
@@ -159,14 +145,15 @@
     }
 
     &__content {
-      padding-top: $gutter-half;
+      padding-top: 5px;
       padding-bottom: $gutter-half;
     }
 
     &--is-open {
       .subsection__content {
         @include media(tablet) {
-          padding-top: 5px;
+          padding-top: 10px;
+          padding-bottom: $gutter;
         }
       }
     }

--- a/app/assets/stylesheets/modules/_subsections.scss
+++ b/app/assets/stylesheets/modules/_subsections.scss
@@ -91,6 +91,7 @@
     &__title {
       button {
         color: $govuk-blue;
+        cursor: pointer;
 
         @include bold-24;
         background: none;

--- a/app/assets/stylesheets/modules/_subsections.scss
+++ b/app/assets/stylesheets/modules/_subsections.scss
@@ -90,7 +90,7 @@
 
     &--is-open {
       .subsection__header {
-        padding-bottom: 5px;
+        padding-bottom: 6px;
       }
     }
 
@@ -133,15 +133,16 @@
 
     &__icon {
       position: absolute;
-      top: 15px;
+      top: 50%;
       right: 0;
 
       @include media (tablet) {
         right: 15px;
       }
 
-      height: 15px;
+      height: 16px;
       width: 16px;
+      margin-top: -8px;
 
       // PNG fallback for SVG
       background-image: image-url('icons-plus-minus.png');


### PR DESCRIPTION
The icon should be 16px in height, set it 50% from the top and with a
negative margin of half its height, so it always sits in the centre.

Also increase the spacing at the bottom of the header, so there isn’t a
“jump” in the position of the icon from plus to minus.

Screenshot before:

![before](https://cloud.githubusercontent.com/assets/417754/15248598/fafdbd72-1912-11e6-8fa6-c330113585d4.png)

Screenshot after:

![after](https://cloud.githubusercontent.com/assets/417754/15248613/1663f554-1913-11e6-8a55-62f637a566a6.png)

