### PR TITLE
Save the state of the accordion using session storage

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -11,52 +11,69 @@
       // Prevent FOUC, remove class hiding content
       $element.removeClass('js-hidden');
 
-      // Insert the markup for the subsection-controls
-      $element.prepend( '<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">Open all</button></div>' );
-
-      var $subsectionTitle = $element.find('.subsection__title');
-
-      // Wrap each title in a button, with aria controls matching the ID of the subsection
-      $subsectionTitle.each(function(index) {
-        $(this).wrapInner( '<button class="subsection__button" aria-expanded="false" aria-controls="subsection_content_'+index+'"></button>' );
-      });
-
       var $subsectionButton = $element.find('.subsection__button');
       var $subsectionHeader = $element.find('.subsection__header');
-
-      // Get all the sections
       var totalSubsections = $element.find('.subsection__content').length;
 
-      // For each of the sections, create a string with all the subsection content IDs
-      var ariaControlsValue = "";
+      var $openOrCloseAllButton;
+      var GOVUKServiceManualTopic;
 
-      for (var i = 0; i < totalSubsections; i++) {
-        ariaControlsValue += "subsection_content_"+i+" ";
+      initialize();
+
+      function initialize() {
+        addOpenCloseAllButton();
+        addSubsectionButtons();
+        addSubsectionIcons();
+        updateSubsectionControls();
+        getServiceManualTopicPrefix();
+        closeOpenSections();
+        checkSessionStorage();
       }
 
-      // Create a unique prefix for each service manual topic
-      var GOVUKserviceManualPrefix = "GOVUK_service_manual";
-      var GOVUKserviceManualTopic = $('h1').text();
-      GOVUKserviceManualTopic = GOVUKserviceManualTopic.replace(/\s+/g,"_");
-      GOVUKserviceManualTopic = GOVUKserviceManualTopic.toLowerCase();
-      var GOVUKServiceManualTopic = GOVUKserviceManualPrefix+"_"+GOVUKserviceManualTopic+"_";
+      function addOpenCloseAllButton() {
+        $element.prepend( '<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">Open all</button></div>' );
+      }
 
-      // Add a data attribute to the wrapper with the current page's topic
-      var $subsectionWrapper = $element.find('.subsection-wrapper');
-      $subsectionWrapper.attr('data-service-manual-topic', GOVUKServiceManualTopic);
+      function addSubsectionButtons() {
+        var $subsectionTitle = $element.find('.subsection__title');
 
-      // Get the open/close all button
-      var $openOrCloseAllButton = $element.find('.js-subsection-controls button');
+        // Wrap each title in a button, with aria controls matching the ID of the subsection
+        $subsectionTitle.each(function(index) {
+          $(this).wrapInner( '<button class="subsection__button" aria-expanded="false" aria-controls="subsection_content_' + index +'"></a>' );
+        });
+      }
 
-      // Set the aria controls for the open/close all button value for all content items
-      $openOrCloseAllButton.attr('aria-controls', ariaControlsValue);
+      function addSubsectionIcons() {
+        $subsectionHeader.append( '<span class="subsection__icon"></span>' );
+      }
 
-      // Hide the content
-      var $subsectionContent = $element.find('.subsection__content');
-      closeSection($subsectionContent);
+      function updateSubsectionControls() {
+        // For each of the sections, create a string with all the subsection content IDs
+        var ariaControlsValue = "";
+        for (var i = 0; i < totalSubsections; i++) {
+          ariaControlsValue += "subsection_content_"+i+" ";
+        }
 
-      // Insert the subsection icon
-      $subsectionHeader.append( '<span class="subsection__icon"></span>' );
+        $openOrCloseAllButton = $element.find('.js-subsection-controls button');
+
+        // Set the aria controls for the open/close all button value for all content items
+        $openOrCloseAllButton.attr('aria-controls', ariaControlsValue);
+      }
+
+      function getServiceManualTopicPrefix() {
+        var GOVUKserviceManualPrefix = "GOVUK_service_manual";
+        var GOVUKserviceManualTopic = $('h1').text();
+        GOVUKserviceManualTopic = GOVUKserviceManualTopic.replace(/\s+/g,"_");
+        GOVUKserviceManualTopic = GOVUKserviceManualTopic.toLowerCase();
+        var GOVUKServiceManualTopic = GOVUKserviceManualPrefix+"_"+GOVUKserviceManualTopic+"_";
+
+        return GOVUKServiceManualTopic;
+      }
+
+      function closeOpenSections() {
+        var $subsectionContent = $element.find('.subsection__content');
+        closeSection($subsectionContent);
+      }
 
       // Add toggle functionality individual sections
       $subsectionHeader.on('click', function(e) {
@@ -76,6 +93,50 @@
         setOpenCloseAllText();
         setSessionStorage();
         removeSessionStorage();
+        return false;
+      });
+
+      $openOrCloseAllButton = $element.find('.js-subsection-controls button');
+      $openOrCloseAllButton.on('click', function(e) {
+        var action = '';
+
+        // update button text
+        if ($openOrCloseAllButton.text() == "Open all") {
+          $openOrCloseAllButton.text("Close all");
+          $openOrCloseAllButton.attr("aria-expanded", "true");
+          action = 'open';
+        } else {
+          $openOrCloseAllButton.text("Open all");
+          $openOrCloseAllButton.attr("aria-expanded", "false");
+          action = 'close';
+        }
+
+        // Set aria-expanded for each button
+        $subsectionButton.each(function( index ) {
+          if (action == 'open') {
+            setExpandedState($(this), "true");
+          } else {
+            setExpandedState($(this), "false");
+          }
+        });
+
+        // show/hide content
+        $subsectionHeader.each(function( index ) {
+          if (action == 'open') {
+            openSection($(this).next());
+            showOpenIcon($(this));
+          } else {
+            closeSection($(this).next());
+            showCloseIcon($(this));
+          }
+        });
+
+        // Add any open sections to Session Storage
+        setSessionStorage();
+
+        // Remove any closed sections from Session Storage
+        removeSessionStorage();
+
         return false;
       });
 
@@ -181,52 +242,6 @@
 
       }
 
-      // Check session storage
-      checkSessionStorage();
-
-      // Add the toggle functionality all sections
-      $openOrCloseAllButton.on('click', function(e) {
-        var action = '';
-
-        // update button text
-        if ($openOrCloseAllButton.text() == "Open all") {
-          $openOrCloseAllButton.text("Close all");
-          $openOrCloseAllButton.attr("aria-expanded", "true");
-          action = 'open';
-        } else {
-          $openOrCloseAllButton.text("Open all");
-          $openOrCloseAllButton.attr("aria-expanded", "false");
-          action = 'close';
-        }
-
-        // Set aria-expanded for each button
-        $subsectionButton.each(function( index ) {
-          if (action == 'open') {
-            setExpandedState($(this), "true");
-          } else {
-            setExpandedState($(this), "false");
-          }
-        });
-
-        // show/hide content
-        $subsectionHeader.each(function( index ) {
-          if (action == 'open') {
-            openSection($(this).next());
-            showOpenIcon($(this));
-          } else {
-            closeSection($(this).next());
-            showCloseIcon($(this));
-          }
-        });
-
-        // Add any open sections to Session Storage
-        setSessionStorage();
-
-        // Remove any closed sections from Session Storage
-        removeSessionStorage();
-
-        return false;
-      });
     }
   };
 })(window.GOVUK.Modules);

--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -53,6 +53,8 @@
         toggleIcon($(this));
         toggleState($(this).find('.subsection__button'));
         setOpenCloseAllText();
+        setSessionStorage();
+        removeSessionStorage();
         return false;
       });
 
@@ -61,6 +63,8 @@
         toggleIcon($(this).parent().parent());
         toggleState($(this));
         setOpenCloseAllText();
+        setSessionStorage();
+        removeSessionStorage();
         return false;
       });
 
@@ -122,6 +126,55 @@
         $node.attr("aria-expanded", state);
       }
 
+      function setSessionStorage() {
+        var isOpenSubsections = $('.subsection--is-open').length;
+        if (isOpenSubsections) {
+          var $openSubsections = $('.subsection--is-open');
+          $openSubsections.each(function(index) {
+            var subsectionOpenContentId = $(this).find('.subsection__content').attr('id');
+            // console.log("Open section: "+subsectionOpenContentId);
+            sessionStorage.setItem( subsectionOpenContentId , subsectionOpenContentId);
+          });
+        }
+      }
+
+      function removeSessionStorage() {
+        var isClosedSubsections = $('.subsection').length;
+        if (isClosedSubsections) {
+          var $closedSubsections = $('.subsection');
+          $closedSubsections.each(function(index) {
+            var subsectionClosedContentId = $(this).find('.subsection__content').attr('id');
+            // console.log("Closed section: "+subsectionClosedContentId);
+            sessionStorage.removeItem( subsectionClosedContentId , subsectionClosedContentId);
+          });
+        }
+      }
+
+      function checkSessionStorage() {
+
+        // Get sections from Session Storage
+        var sessionStorageItems = [];
+        for ( var i = 0, len = sessionStorage.length; i < len; ++i ) {
+          sessionStorageItems.push(sessionStorage.key( i ));
+        }
+
+        // For each item in sessionStorage, this is the ID of the open section
+        // Change class to '.subsection--is-open' and the section will open
+        $.each( sessionStorageItems, function( key, value ) {
+          // console.log( key + ": " + value );
+          var $sectionInStorage = $('#'+value);
+
+          openSection($sectionInStorage);
+          var action = 'open';
+          // We want to update the button, with the aria-controls value matching the value above
+          // Only do it for this open section
+          setExpandedState($('button').attr('aria-conrols',value), "true");
+        });
+      }
+
+      // Check session storage
+      checkSessionStorage();
+
       // Add the toggle functionality all sections
       $openOrCloseAllButton.on('click', function(e) {
         var action = '';
@@ -156,6 +209,12 @@
             showCloseIcon($(this));
           }
         });
+
+        // Add any open sections to Session Storage
+        setSessionStorage();
+
+        // Remove any closed sections from Session Storage
+        removeSessionStorage();
 
         return false;
       });

--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -8,7 +8,7 @@
       // Indicate that js has worked
       $element.addClass('js-accordion-with-descriptions');
 
-       // Prevent FOUC, remove class hiding content
+      // Prevent FOUC, remove class hiding content
       $element.removeClass('js-hidden');
 
       // Insert the markup for the subsection-controls
@@ -33,6 +33,17 @@
       for (var i = 0; i < totalSubsections; i++) {
         ariaControlsValue += "subsection_content_"+i+" ";
       }
+
+      // Create a unique prefix for each service manual topic
+      var GOVUKserviceManualPrefix = "GOVUK_service_manual";
+      var GOVUKserviceManualTopic = $('h1').text();
+      GOVUKserviceManualTopic = GOVUKserviceManualTopic.replace(/\s+/g,"_");
+      GOVUKserviceManualTopic = GOVUKserviceManualTopic.toLowerCase();
+      var GOVUKServiceManualTopic = GOVUKserviceManualPrefix+"_"+GOVUKserviceManualTopic+"_";
+
+      // Add a data attribute to the wrapper with the current page's topic
+      var $subsectionWrapper = $element.find('.subsection-wrapper');
+      $subsectionWrapper.attr('data-service-manual-topic', GOVUKServiceManualTopic);
 
       // Get the open/close all button
       var $openOrCloseAllButton = $element.find('.js-subsection-controls button');
@@ -67,6 +78,13 @@
         removeSessionStorage();
         return false;
       });
+
+      function openStoredSections($section) {
+        toggleSection($section);
+        toggleIcon($section);
+        toggleState($section.parent().find('.subsection__button'));
+        setOpenCloseAllText();
+      }
 
       function setOpenCloseAllText() {
         var openSubsections = $('.subsection--is-open').length;
@@ -132,8 +150,7 @@
           var $openSubsections = $('.subsection--is-open');
           $openSubsections.each(function(index) {
             var subsectionOpenContentId = $(this).find('.subsection__content').attr('id');
-            // console.log("Open section: "+subsectionOpenContentId);
-            sessionStorage.setItem( subsectionOpenContentId , subsectionOpenContentId);
+            sessionStorage.setItem( GOVUKServiceManualTopic+subsectionOpenContentId , 'Opened');
           });
         }
       }
@@ -144,32 +161,24 @@
           var $closedSubsections = $('.subsection');
           $closedSubsections.each(function(index) {
             var subsectionClosedContentId = $(this).find('.subsection__content').attr('id');
-            // console.log("Closed section: "+subsectionClosedContentId);
-            sessionStorage.removeItem( subsectionClosedContentId , subsectionClosedContentId);
+            sessionStorage.removeItem( GOVUKServiceManualTopic+subsectionClosedContentId , subsectionClosedContentId);
           });
         }
       }
 
       function checkSessionStorage() {
 
-        // Get sections from Session Storage
-        var sessionStorageItems = [];
-        for ( var i = 0, len = sessionStorage.length; i < len; ++i ) {
-          sessionStorageItems.push(sessionStorage.key( i ));
-        }
+        var $subsectionContent = $element.find('.subsection__content');
 
-        // For each item in sessionStorage, this is the ID of the open section
-        // Change class to '.subsection--is-open' and the section will open
-        $.each( sessionStorageItems, function( key, value ) {
-          // console.log( key + ": " + value );
-          var $sectionInStorage = $('#'+value);
-
-          openSection($sectionInStorage);
-          var action = 'open';
-          // We want to update the button, with the aria-controls value matching the value above
-          // Only do it for this open section
-          setExpandedState($('button').attr('aria-conrols',value), "true");
+        $subsectionContent.each(function(index) {
+          var subsectionContentId = $(this).attr('id');
+          if(sessionStorage.getItem(GOVUKServiceManualTopic+subsectionContentId)){
+            openStoredSections($("#"+subsectionContentId));
+          }
         });
+
+        setOpenCloseAllText();
+
       }
 
       // Check session storage

--- a/spec/javascripts/accordion-with-descriptions-spec.js
+++ b/spec/javascripts/accordion-with-descriptions-spec.js
@@ -163,6 +163,20 @@ describe('An accordion with descriptions module', function () {
       expect($subsectionButton).toHaveAttr('aria-expanded','true');
     });
 
+    it("has its state saved in session storage", function () {
+      var GOVUKServiceManualTopic = "GOVUK_service_manual_agile_delivery";
+
+      var $subsectionButton = $element.find('.subsection__title button');
+      $subsectionButton.click();
+
+      var $openSubsections = $('.subsection--is-open');
+      var subsectionOpenContentId = $openSubsections.find('.subsection__content').attr('id');
+      sessionStorage.setItem(GOVUKServiceManualTopic+subsectionOpenContentId , 'Opened');
+
+      var storedItem = sessionStorage.getItem(GOVUKServiceManualTopic+subsectionOpenContentId);
+      expect(storedItem).toEqual('Opened');
+    });
+
   });
 
   describe('When a section is closed', function () {
@@ -185,6 +199,16 @@ describe('An accordion with descriptions module', function () {
       expect($subsectionButton).toHaveAttr('aria-expanded','true');
       $subsectionButton.click();
       expect($subsectionButton).toHaveAttr('aria-expanded','false');
+    });
+
+    it("has its state removed in session storage", function () {
+      var GOVUKServiceManualTopic = "GOVUK_service_manual_agile_delivery";
+
+      var $closedSubsections = $element.find('.subsection');
+      var subsectionClosedContentId = $closedSubsections.find('.subsection__content').attr('id');
+      sessionStorage.removeItem(GOVUKServiceManualTopic+subsectionClosedContentId , 'Opened');
+      var removedItem = sessionStorage.getItem(GOVUKServiceManualTopic+subsectionClosedContentId);
+      expect(removedItem).not.toExist();
     });
 
   });

--- a/spec/javascripts/accordion-with-descriptions-spec.js
+++ b/spec/javascripts/accordion-with-descriptions-spec.js
@@ -130,7 +130,7 @@ describe('An accordion with descriptions module', function () {
     });
 
     // Check that the total number of is-open classes matches the number of sections (so all are opened)
-    it("has two subsections which have an open state (this is equal to the totoal number of sections), the button text should be Close all", function () {
+    it("has two subsections which have an open state (this is equal to the total number of sections), the button text should be Close all", function () {
       var $openCloseAllButton = $element.find('.js-subsection-controls button');
       var openSubsections = $element.find('.subsection--is-open').length;
 


### PR DESCRIPTION
When a section is opened - save its ID (with a prefix that identifies it as coming from the GOVUK Service Manual) to local storage with a value of 'Opened' and when it is closed, remove this key from session storage.

When the page loads, check session storage to see if any items have previously been stored and if so, open that section and set the `aria-expanded` attribute of the button to `true`.

cc @thehenster.