### PR TITLE
Change the page contents title to a h2

### DIFF
--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -65,7 +65,7 @@
 
     <!--  Page contents -->
     <div class="page-contents">
-      <h3 class="page-contents__title">Page contents:</h3>
+      <h2 class="page-contents__title">Page contents:</h2>
       <ul class="page-contents__list">
         <% @content_item.header_links.each do |header_link| %>
           <li><a href="<%=header_link[:href]%>"><%=header_link[:title]%></a></li>


### PR DESCRIPTION
It is helpful to screenreaders to maintain a logical heading hierarchy, so this should be a `<h2>`, as it is
the next heading after the `<h1>`.

cc. @aduggin 