### PR TITLE
Remove unused fields from service manual guide

### DIFF
--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -13,18 +13,8 @@ class ServiceManualGuidePresenter < ContentItemPresenter
   end
 
   def content_owners
-    if links_content_owners_attributes.any?
-      links_content_owners_attributes.map do |content_owner_attributes|
-        ContentOwner.new(content_owner_attributes["title"], content_owner_attributes["base_path"])
-      end
-    else
-      # During a migration period we need to be able to retrieve content owners
-      # from the details as well. Once all guides have been republished and no
-      # guides contain content_owners in the details then this branch and
-      # associated private method can be removed.
-      details_content_owners_attributes.map do |content_owner_attributes|
-        ContentOwner.new(content_owner_attributes["title"], content_owner_attributes["href"])
-      end
+    links_content_owners_attributes.map do |content_owner_attributes|
+      ContentOwner.new(content_owner_attributes["title"], content_owner_attributes["base_path"])
     end
   end
 
@@ -70,9 +60,5 @@ private
 
   def links_content_owners_attributes
     content_item.to_hash.fetch('links', {}).fetch('content_owners', [])
-  end
-
-  def details_content_owners_attributes
-    [content_item.to_hash.fetch('details', {}).fetch('content_owner', nil)].compact
   end
 end

--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -1,6 +1,5 @@
 class ServiceManualGuidePresenter < ContentItemPresenter
   ContentOwner = Struct.new(:title, :href)
-  RelatedDiscussion = Struct.new(:title, :href)
 
   include ActionView::Helpers::DateHelper
   attr_reader :body, :publish_time, :header_links

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -44,12 +44,6 @@
             </dd>
           <% end %>
         <% end %>
-        <% if @content_item.related_discussion %>
-          <dt>Related discussion:</dt>
-          <dd>
-            <%= link_to @content_item.related_discussion.title, @content_item.related_discussion.href, rel: 'external' %>
-          </dd>
-        <% end %>
         <dt>Last updated:</dt>
         <dd>
           <%= @content_item.last_published_time_in_words %>

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -13,7 +13,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "gets item from content store" do
-    content_item = content_store_has_schema_example('service_manual_guide', 'basic_with_related_discussions')
+    content_item = content_store_has_schema_example('service_manual_guide', 'service_manual_guide')
 
     get :show, path: path_for(content_item)
     assert_response :success
@@ -21,7 +21,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "sets the expiry as sent by content-store" do
-    content_item = content_store_has_schema_example('service_manual_guide', 'basic_with_related_discussions')
+    content_item = content_store_has_schema_example('service_manual_guide', 'service_manual_guide')
     content_store_has_item(content_item['base_path'], content_item, max_age: 20)
 
     get :show, path: path_for(content_item)
@@ -30,7 +30,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "honours cache-control private items" do
-    content_item = content_store_has_schema_example('service_manual_guide', 'basic_with_related_discussions')
+    content_item = content_store_has_schema_example('service_manual_guide', 'service_manual_guide')
     content_store_has_item(content_item['base_path'], content_item, private: true)
 
     get :show, path: path_for(content_item)
@@ -39,7 +39,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test "gets item from content store even when url contains multi-byte UTF8 character" do
-    content_item = content_store_has_schema_example('service_manual_guide', 'basic_with_related_discussions')
+    content_item = content_store_has_schema_example('service_manual_guide', 'service_manual_guide')
     utf8_path    = "government/case-studies/caf\u00e9-culture"
     content_item['base_path'] = "/#{utf8_path}"
 
@@ -68,7 +68,7 @@ class ContentItemsControllerTest < ActionController::TestCase
   end
 
   test 'renders service manual guides' do
-    content_item = content_store_has_schema_example('service_manual_guide', 'basic_with_related_discussions')
+    content_item = content_store_has_schema_example('service_manual_guide', 'service_manual_guide')
 
     get :show, path: path_for(content_item)
     ENV.delete("FLAG_ENABLE_SERVICE_MANUAL")

--- a/test/integration/government_navigation_test.rb
+++ b/test/integration/government_navigation_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class GovernmentNavigationTest < ActionDispatch::IntegrationTest
   test "includes government navigation" do
-    example_body = get_content_example_by_format_and_name('service_manual_guide', 'basic_with_related_discussions')
+    example_body = get_content_example_by_format_and_name('service_manual_guide', 'service_manual_guide')
     base_path = JSON.parse(example_body).fetch("base_path")
     content_store_has_item(base_path, example_body)
 

--- a/test/integration/phase_label_test.rb
+++ b/test/integration/phase_label_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PhaseLabelTest < ActionDispatch::IntegrationTest
   test "Beta phase label is displayed for a Service Manual Guide in phase 'beta'" do
-    guide_sample = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'basic_with_related_discussions'))
+    guide_sample = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'service_manual_guide'))
     guide_sample.merge!("phase" => "beta")
     content_store_has_item("/service-manual/agile", guide_sample.to_json)
 
@@ -12,7 +12,7 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
   end
 
   test "renders custom message for service manual guide pages" do
-    guide_sample = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'basic_with_related_discussions'))
+    guide_sample = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'service_manual_guide'))
     phase = 'beta'
     guide_sample["phase"] = phase
     content_store_has_item("/service-manual/agile", guide_sample.to_json)
@@ -24,7 +24,7 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
   end
 
   test "Alpha phase label is displayed for a Case Study in phase 'alpha'" do
-    case_study = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'basic_with_related_discussions'))
+    case_study = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'service_manual_guide'))
     case_study.merge!("phase" => "alpha")
     content_store_has_item("/government/case-studies/get-britain-building-carlisle-park", case_study.to_json)
 
@@ -34,7 +34,7 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
   end
 
   test "No phase label is displayed for a Content item without a phase field" do
-    content_item = content_store_has_schema_example('service_manual_guide', 'basic_with_related_discussions')
+    content_item = content_store_has_schema_example('service_manual_guide', 'service_manual_guide')
     content_item.delete("phase")
     content_store_has_item("/government/case-studies/get-britain-building-carlisle-park", content_item.to_json)
 

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ServiceManualGuideTest < ActionDispatch::IntegrationTest
   test "service manual guide shows content owners" do
-    setup_and_visit_example('service_manual_guide', 'basic_with_related_discussions')
+    setup_and_visit_example('service_manual_guide', 'service_manual_guide')
 
     within('.metadata') do
       assert page.has_link?('Agile delivery community')
@@ -26,7 +26,7 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
   end
 
   test "the lede is not visible unless there is a summary" do
-    setup_and_visit_example('service_manual_guide', 'basic_with_related_discussions')
+    setup_and_visit_example('service_manual_guide', 'service_manual_guide')
 
     refute page.has_css?('.lede')
   end

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -10,10 +10,6 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     content_owner = presented_guide.content_owners.first
     assert content_owner.title.present?
     assert content_owner.href.present?
-
-    related_discussion = presented_guide.related_discussion
-    assert related_discussion.title.present?
-    assert related_discussion.href.present?
   end
 
   test '#last_published_time_in_words outputs a human readable definition of time ago' do
@@ -77,7 +73,7 @@ private
 
   def presented_guide(overriden_attributes = {})
     ServiceManualGuidePresenter.new(
-      JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'basic_with_related_discussions')).merge(overriden_attributes)
+      JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('service_manual_guide', 'service_manual_guide')).merge(overriden_attributes)
     )
   end
 end

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -73,20 +73,6 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     assert_equal expected, guide.content_owners
   end
 
-  test '#content_owner falls back to using deprecated content owner info in details' do
-    guide = presented_guide(
-      'details' => { 'content_owner' => { 'title' => 'Agile Community', 'href' => '/service-manual/communities/agile-delivery-community' } },
-      'links' => {}
-    )
-
-    expected = [
-      ServiceManualGuidePresenter::ContentOwner.new(
-        "Agile Community",
-        "/service-manual/communities/agile-delivery-community")
-    ]
-    assert_equal expected, guide.content_owners
-  end
-
 private
 
   def presented_guide(overriden_attributes = {})


### PR DESCRIPTION
Removes related_discussion which is no longer used and content_owner which has been moved to the links.

Related content schemas PR: https://github.com/alphagov/govuk-content-schemas/pull/313