### PR TITLE
Base guide breadcrumb on service_manual_topics field

### DIFF
--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -32,10 +32,6 @@ class ServiceManualGuidePresenter < ContentItemPresenter
     updated_at.strftime("%e %B %Y %H:%M")
   end
 
-  def main_topic
-    @main_topic ||= Array(content_item["links"] && content_item["links"]["topics"]).first
-  end
-
   def main_topic_title
     main_topic["title"] if main_topic.present?
   end
@@ -59,5 +55,9 @@ private
 
   def links_content_owners_attributes
     content_item.to_hash.fetch('links', {}).fetch('content_owners', [])
+  end
+
+  def main_topic
+    @main_topic ||= Array(content_item["links"] && content_item["links"]["service_manual_topics"]).first
   end
 end

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -9,6 +9,26 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "the breadcrumb contains the topic" do
+    setup_and_visit_example('service_manual_guide', 'service_manual_guide')
+    breadcrumbs = [
+      {
+        title: "Service manual",
+        url: "/service-manual"
+      },
+      {
+        title: "Agile",
+        url: "/service-manual/agile"
+      },
+      {
+        title: "Agile Delivery"
+      }
+    ]
+    within shared_component_selector("breadcrumbs") do
+      assert_equal breadcrumbs, JSON.parse(page.text).deep_symbolize_keys.fetch(:breadcrumbs)
+    end
+  end
+
   test "service manual guide does not show published by" do
     setup_and_visit_example('service_manual_guide', 'service_manual_guide_community')
 

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
   test 'presents the basic details required to display a Service Manual Guide' do
-    assert_equal "Agile", presented_guide.title
+    assert_equal "Agile Delivery", presented_guide.title
     assert_equal "service_manual_guide", presented_guide.format
     assert presented_guide.body.size > 10
     assert presented_guide.header_links.size >= 1
@@ -23,31 +23,31 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
   end
 
   test 'breadcrumbs have a root and a topic link' do
-    presented_guide = presented_guide("links" => { "topics" => [{ "title" => "Topic", "base_path" => "/service-manual/topic" }] })
+    guide = presented_guide
     assert_equal [
                    { title: "Service manual", url: "/service-manual" },
-                   { title: "Topic", url: "/service-manual/topic" },
-                   { title: "Agile" },
+                   { title: "Agile", url: "/service-manual/agile" },
+                   { title: "Agile Delivery" },
                  ],
-                 presented_guide.breadcrumbs
+                 guide.breadcrumbs
   end
 
   test "breadcrumbs gracefully omit topic if it's not present" do
     presented_guide = presented_guide("links" => {})
     assert_equal [
                    { title: "Service manual", url: "/service-manual" },
-                   { title: "Agile" },
+                   { title: "Agile Delivery" },
                  ],
                  presented_guide.breadcrumbs
   end
 
   test "#main_topic_title is the title of the main topic" do
-    guide = presented_guide("links" => { "topics" => [{ "title" => "Agile Delivery", "base_path" => "/service-manual/topic" }] })
-    assert_equal 'Agile Delivery', guide.main_topic_title
+    guide = presented_guide
+    assert_equal 'Agile', guide.main_topic_title
   end
 
   test "#main_topic_title can be empty" do
-    guide = presented_guide
+    guide = presented_guide("links" => {})
     assert_nil guide.main_topic_title
   end
 


### PR DESCRIPTION
This field was renamed from 'topics' as it is a reserved field.