### PR TITLE
Create a page header module with markup example

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,5 +17,6 @@
 @import "modules/metadata";
 @import "modules/notice";
 @import "modules/page-contents";
+@import "modules/page-header";
 @import "modules/related-content";
 @import "modules/subsections";

--- a/app/assets/stylesheets/modules/_page-header.scss
+++ b/app/assets/stylesheets/modules/_page-header.scss
@@ -1,0 +1,38 @@
+// Example usage:
+
+// <div class="page-header">
+//   <p class="page-header__context">Context</p>
+//   <h1 class="page-header__title">Agile delivery</h1>
+//   <p class="page-header__summary">
+//     How to work in an agile way: principles, tools and governance.
+//   </p>
+//   <p class="page-header__description">
+//     Additional descriptive text can sit here
+//   </p>
+// </div>
+
+// Here we're using BEM which uses __ to denote an element within a block
+// scss-lint:disable SelectorFormat
+.page-header {
+  @include responsive-vertical-margins;
+}
+
+.page-header__context {
+  @include core-24;
+
+  color: $secondary-text-colour;
+}
+
+.page-header__title {
+  @include bold-48;
+}
+
+.page-header__summary {
+  @include core-24;
+
+  @include responsive-bottom-margin;
+}
+
+.page-header__description {
+  @include core-19;
+}


### PR DESCRIPTION
This module can be used on all Service manual page types.

**Service manual - Service Standard page**
```
<div class="page-header">
  <h1 class="page-header__title">Digital Service Standard</h1>
  <p class="page-header__summary">
    The Digital Service Standard is a set of 18 criteria to help government create and run good digital services.
  </p>
  <p class="page-header__description">
    All public facing transactional services must meet the standard. It’s used by departments and the Government Digital Service to check whether a service is good enough for public use.
  </p>
</div>
```

**Service manual - Topic page**
```
<div class="page-header">
  <h1 class="page-header__title">Agile delivery</h1>
  <p class="page-header__summary">
    How to work in an agile way: principles, tools and governance.
  </p>
</div>
```

**Service manual - Guide page**
```
<div class="page-header">
  <p class="page-header__context">Agile delivery</p>
  <h1 class="page-header__title">
    Agile and government services: an introduction
  </h1>
</div>
```