### PR TITLE
Make accordion description text darker

### DIFF
--- a/app/assets/stylesheets/modules/_subsections.scss
+++ b/app/assets/stylesheets/modules/_subsections.scss
@@ -19,7 +19,6 @@
 
   &__description {
     @include core-19;
-    color: $secondary-text-colour;
     margin-bottom: $gutter-one-quarter;
 
     @include media(tablet) {


### PR DESCRIPTION
The text will then default to $text-colour, which is #0b0c0c.

Before:
![user research gov uk - before](https://cloud.githubusercontent.com/assets/417754/16450249/037e74b8-3df4-11e6-95b2-7a3f7055c4be.png)

After:
![user research gov uk - after](https://cloud.githubusercontent.com/assets/417754/16450727/8f0d565a-3df6-11e6-95b4-ff790d7290d5.png)

