### PR TITLE
Make page titles consistent

### DIFF
--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :page_class, "service-manual" %>
-<%= content_for :title, @content_item.title %>
+<%= content_for :title, "#{@content_item.title} - Digital Service Manual" %>
 
 <% content_for :phase_message do %>
   <%= render 'shared/service_manual_custom_phase_message', phase: @content_item.phase %>


### PR DESCRIPTION
Both Topic and Guide pages should display the page name, followed by -
Digital Service Manual - GOV.UK in the page title.

This was missing from the Topic page, and is added here.