### PR TITLE
Sort service standard points numerically

### DIFF
--- a/app/presenters/service_manual_service_standard_presenter.rb
+++ b/app/presenters/service_manual_service_standard_presenter.rb
@@ -1,7 +1,6 @@
 class ServiceManualServiceStandardPresenter < ContentItemPresenter
   def points
-    point_hashes = Array(content_item["details"]["points"])
-    point_hashes.sort_by { |point_hash| point_hash["title"] }
+    Point.load(points_attributes).sort
   end
 
   def breadcrumbs
@@ -9,5 +8,39 @@ class ServiceManualServiceStandardPresenter < ContentItemPresenter
       { title: "Service manual", url: "/service-manual" },
       { title: title }
     ]
+  end
+
+private
+
+  def points_attributes
+    @_points_attributes ||= details["points"] || []
+  end
+
+  def details
+    @_details ||= content_item["details"] || {}
+  end
+
+  class Point
+    include Comparable
+
+    attr_reader :title, :summary, :base_path
+
+    def self.load(points_attributes)
+      points_attributes.map { |point_attributes| new(point_attributes) }
+    end
+
+    def initialize(attributes)
+      @title = attributes["title"]
+      @summary = attributes["summary"]
+      @base_path = attributes["base_path"]
+    end
+
+    def <=>(other)
+      number <=> other.number
+    end
+
+    def number
+      @_number ||= Integer(title.scan(/\A(\d*)/)[0][0])
+    end
   end
 end

--- a/app/views/content_items/service_manual_service_standard.html.erb
+++ b/app/views/content_items/service_manual_service_standard.html.erb
@@ -27,14 +27,14 @@
 <div class="grid-row">
 
   <div class="column-two-thirds">
-    <% @content_item.points.each.with_index do |point, point_index| %>
-      <% point_position = point_index + 1 %>
-      <div class="service-standard-point" id="criterion-<%= point_position -%>">
-        <h2 class="service-standard-point__title"><%= point["title"] %></h2>
+    <% @content_item.points.each do |point| %>
+
+      <div class="service-standard-point"  id="criterion-<%= point.number -%>">
+        <h2 class="service-standard-point__title"><%= point.title %></h2>
 
         <div class="service-standard-point__details">
-          <p><%= point["summary"] %></p>
-          <p class="service-standard-point__link"><%= link_to "Read more about point #{ point_position }", point["base_path"] %></p>
+          <p><%= point.summary %></p>
+          <p class="service-standard-point__link"><%= link_to "Read more about point #{ point.number }", point.base_path %></p>
         </div>
       </div>
     <% end %>

--- a/test/presenters/service_manual_service_standard_presenter_test.rb
+++ b/test/presenters/service_manual_service_standard_presenter_test.rb
@@ -9,26 +9,49 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
 
     points = ServiceManualServiceStandardPresenter.new(JSON.parse(example)).points
 
-    assert points.any? { |point_hash| point_hash["title"] == "1. Understand user needs" }
-    assert points.any? { |point_hash| point_hash["title"] == "2. Do ongoing user research" }
+    assert points.any? { |point_hash| point_hash.title == "1. Understand user needs" }
+    assert points.any? { |point_hash| point_hash.title == "2. Do ongoing user research" }
   end
 
-  test "#points returns points ordered by title" do
+  test "#points returns points ordered numerically" do
     content_item_hash = {
       "details" => {
         "points" => [
-          { "title" => "3. Have a multidisciplinary team" },
-          { "title" => "1. Understand user needs" },
-          { "title" => "2. Do ongoing user research" },
+          { "title" => "3. Title" },
+          { "title" => "1. Title" },
+          { "title" => "9. Title" },
+          { "title" => "10. Title" },
+          { "title" => "5. Title" },
+          { "title" => "6. Title" },
+          { "title" => "2. Title" },
+          { "title" => "4. Title" },
+          { "title" => "7. Title" },
+          { "title" => "11. Title" },
+          { "title" => "8. Title" },
         ]
       }
     }
 
-    points = ServiceManualServiceStandardPresenter.new(content_item_hash).points
+    points_titles =
+      ServiceManualServiceStandardPresenter.new(content_item_hash).points.map(&:title)
 
-    assert_equal points[0]["title"], "1. Understand user needs"
-    assert_equal points[1]["title"], "2. Do ongoing user research"
-    assert_equal points[2]["title"], "3. Have a multidisciplinary team"
+    assert_equal points_titles, [
+      "1. Title",
+      "2. Title",
+      "3. Title",
+      "4. Title",
+      "5. Title",
+      "6. Title",
+      "7. Title",
+      "8. Title",
+      "9. Title",
+      "10. Title",
+      "11. Title",
+    ]
+  end
+
+  test "#points is empty if there aren't any points in the content item" do
+    assert ServiceManualServiceStandardPresenter.new({}).points.empty?
   end
 
   test "#breadcrumbs contains a link to the service manual root" do


### PR DESCRIPTION
This fixes the bug where we sorted alphabetically and 10 came after 1 rather than 2.