### PR TITLE
Put the give feedback link back

### DIFF
--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -23,6 +23,15 @@
     <% end %>
     </div>
   </div>
+
+  <div class="column-third">
+
+    <div class="community-contact">
+      <p>
+        <%= link_to "Give feedback about this page", "/contact/govuk", class: "feedback" %>
+      </p>
+    </div>
+  </div>
 </div>
 
 <!-- Metadata-->

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -50,4 +50,10 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
 
     refute page.has_css?('.lede')
   end
+
+  test "displays a link to give feedback" do
+    setup_and_visit_example('service_manual_guide', 'service_manual_guide')
+
+    assert page.has_link?('Give feedback about this page')
+  end
 end


### PR DESCRIPTION
Until we finalise the design for the feedback footer we might be losing people who would otherwise give feedback. This reapplies the original link on the guide, point and community page.

https://trello.com/c/SPR7fOQG