### PR TITLE
Show the description for a point based on a boolean

### DIFF
--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -6,8 +6,8 @@ class ServiceManualGuidePresenter < ContentItemPresenter
 
   def initialize(content_item)
     super
-    @body = content_item["details"]["body"]
-    @header_links = Array(content_item["details"]["header_links"])
+    @body = details["body"]
+    @header_links = Array(details["header_links"])
       .map { |h| ActiveSupport::HashWithIndifferentAccess.new(h) }
   end
 
@@ -32,8 +32,8 @@ class ServiceManualGuidePresenter < ContentItemPresenter
     crumbs
   end
 
-  def summary
-    content_item['details']['summary']
+  def show_description?
+    !!details['show_description']
   end
 
 private
@@ -60,5 +60,9 @@ private
 
   def links
     @_links ||= content_item["links"] || {}
+  end
+
+  def details
+    @_details ||= content_item["details"] || {}
   end
 end

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -16,9 +16,9 @@
       <h1 class="page-header__title">
         <%= @content_item.title %>
       </h1>
-    <% if @content_item.summary.present? %>
+    <% if @content_item.show_description? %>
       <p class="page-header__summary">
-        <%= @content_item.summary %>
+        <%= @content_item.description %>
       </p>
     <% end %>
     </div>

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -37,7 +37,7 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "displays a summary if present" do
+  test "displays the description for a point" do
     setup_and_visit_example('service_manual_guide', 'point_page')
 
     within('.page-header__summary') do
@@ -45,10 +45,10 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "the lede is not visible unless there is a summary" do
+  test "does not display the description for a normal guide" do
     setup_and_visit_example('service_manual_guide', 'service_manual_guide')
 
-    refute page.has_css?('.lede')
+    refute page.has_css?('.page-header__summary')
   end
 
   test "displays a link to give feedback" do

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -75,6 +75,10 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     assert_equal expected, guide.content_owners
   end
 
+  test "#show_description? is false if not set" do
+    refute ServiceManualGuidePresenter.new({}).show_description?
+  end
+
 private
 
   def presented_guide(overriden_attributes = {})


### PR DESCRIPTION
Because we can use the description for the point text this bases whether we display the point text (or summary) on a boolean instead.