### PR TITLE
[DO NOT MERGE] A stab at the reduced header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,3 +20,4 @@
 @import "modules/related-content";
 @import "modules/subsections";
 @import "modules/service-standard-point";
+@import "modules/search";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,5 +19,5 @@
 @import "modules/page-header";
 @import "modules/related-content";
 @import "modules/subsections";
+@import "modules/service-manual-header";
 @import "modules/service-standard-point";
-@import "modules/search";

--- a/app/assets/stylesheets/modules/_search.scss
+++ b/app/assets/stylesheets/modules/_search.scss
@@ -1,0 +1,4 @@
+#search {
+  width: 50%;
+  float: right;
+}

--- a/app/assets/stylesheets/modules/_search.scss
+++ b/app/assets/stylesheets/modules/_search.scss
@@ -1,4 +1,0 @@
-#search {
-  width: 50%;
-  float: right;
-}

--- a/app/assets/stylesheets/modules/_service-manual-header.scss
+++ b/app/assets/stylesheets/modules/_service-manual-header.scss
@@ -1,0 +1,69 @@
+// Override the existing GOV.UK header with proposition
+.js-header-toggle {
+  display: none !important;
+}
+
+#global-header .header-proposition {
+  padding-top: 0;
+}
+
+#global-header.with-proposition #search {
+  margin-top: 0;
+}
+
+@media screen and (max-width: 379px) {
+  #global-header form#search {
+    display: block;
+    width: 100%;
+  }
+}
+
+#global-header .header-proposition #proposition-menu {
+  margin-top: 0;
+}
+
+.service-manual-header-title {
+
+  width: auto;
+  float: left;
+  position: relative;
+
+  @include media (mobile) {
+    top: 7px;
+    font-size: 24px;
+  }
+
+  top: 6px;
+
+  @include core-24;
+
+  font-weight: bold;
+
+  a {
+    color: $white;
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+}
+
+.service-manual-header-search {
+
+  margin-top: 4px;
+  @extend %contain-floats;
+
+  @media screen and (max-width: 379px) {
+    width: 100%;
+    float: left;
+  }
+
+  width: 49%;
+  float: right;
+
+  .content {
+    margin: 0 !important;
+  }
+}

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -16,9 +16,7 @@ class ContentItemsController < ApplicationController
     #   <input type="hidden" name="filter_manual" value="/service-manual">
     # </form>
     set_slimmer_headers(
-      search_parameters: {
-        "filter_manual" => "/service-manual"
-      }.to_json,
+      remove_search: true
     )
 
     if load_content_item

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,22 @@
   <% end %>
 </head>
 <body>
-  <% unless content_for(:simple_header) %>
-    <%= render partial: 'govuk_component/government_navigation' %>
-  <% end %>
+  <div class="header-proposition">
+    <div class="content">
+      <nav id="proposition-menu">
+        <a href="/" id="proposition-name">Service manual</a>
+
+        <form id="search" class="site-search" action="/search" method="get" role="search">
+          <div class="content">
+            <label for="site-search-text">Search the Service Manual</label>
+            <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
+            <input type="hidden" name="filter_manual" value="/service-manual">
+            <input class="submit" type="submit" value="Search" />
+          </div>
+        </form>
+      </nav>
+    </div>
+  </div>
 
   <div id="wrapper" class="<%= wrapper_class %>">
     <main role="main" id="content" class="<%= yield(:page_class) %>" lang="<%= I18n.locale %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,11 +14,14 @@
   <% end %>
 </head>
 <body>
-  <div class="header-proposition">
-    <div class="content">
-      <nav id="proposition-menu">
-        <a href="/" id="proposition-name">Service manual</a>
 
+  <!-- Keep #proposition-menu here, only for the purpose of moving this via Slimmer -->
+  <div id="proposition-menu">
+    <div class="service-manual-header">
+      <div class="service-manual-header-title">
+        <a href="/">Service manual</a>
+      </div>
+      <div class="service-manual-header-search">
         <form id="search" class="site-search" action="/search" method="get" role="search">
           <div class="content">
             <label for="site-search-text">Search the Service Manual</label>
@@ -27,9 +30,10 @@
             <input class="submit" type="submit" value="Search" />
           </div>
         </form>
-      </nav>
+      </div>
     </div>
   </div>
+  <!-- End #proposition-menu wrapper, only for the purpose of moving this via Slimmer -->
 
   <div id="wrapper" class="<%= wrapper_class %>">
     <main role="main" id="content" class="<%= yield(:page_class) %>" lang="<%= I18n.locale %>">


### PR DESCRIPTION
We're trying to change the header in the following ways:

* Remove the government navigation links
* Scope the search to the service manual
* Change the search box label to 'Search the Service Manual'
* Add a title of 'Service Manual'

Here is the design:

![searchbar results-02](https://cloud.githubusercontent.com/assets/78311/16801220/48c1d90e-48f1-11e6-925d-379cd1df8cd2.png)

This stab, iffy padding/styling aside, meets the criteria.

<img width="1005" alt="screen shot 2016-07-12 at 17 07 22" src="https://cloud.githubusercontent.com/assets/78311/16774840/b74eef98-4855-11e6-8b13-0bbd06ce980a.png">

To achieve this we've:

* Set a slimmer header to remove the default search bar
* Stuck in our own `proposition-menu` that contains:
  * A proposition-name for the title
  * A custom search bar with the `filter-manual` parameter and our custom label

We almost got away with taking advantage of Slimmer's `Search-Parameters` header, which let us specify the `filter-manual` parameter, but as we needed the custom label it was removed.

Is there a better way?