### PR TITLE
Don't render blank section headings for topics 'without sections'

### DIFF
--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -22,35 +22,31 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <% if @content_item.visually_collapsed? %>
-      <div class="js-hidden" data-module="accordion-with-descriptions">
-    <% else %>
-      <div>
-    <% end %>
-      <div class="subsection-wrapper">
-
-        <% @content_item.groups.each_with_index do |link_group, idx| %>
-
-          <div class="subsection">
-            <div class="subsection__header">
-              <h2 class="subsection__title"><%= link_group.name %></h2>
-              <p class="subsection__description"><%= link_group.description %></p>
+      <div<% if @content_item.visually_collapsed? %> class="js-hidden" data-module="accordion-with-descriptions"<% end %>>
+        <div class="subsection-wrapper">
+          <% @content_item.groups.each_with_index do |link_group, idx| %>
+            <div class="subsection">
+            <% if link_group.name.present? %>
+              <div class="subsection__header">
+                <h2 class="subsection__title"><%= link_group.name %></h2>
+              <% if link_group.description.present? %>
+                <p class="subsection__description"><%= link_group.description %></p>
+              <% end %>
+              </div>
+            <% end %>
+              <div class="subsection__content" id="subsection_content_<%= idx %>">
+                <ul class="subsection__list">
+                  <% link_group.linked_items.each do |linked_item| %>
+                    <li class="subsection__list-item">
+                      <%= link_to linked_item.label, linked_item.href %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
             </div>
-            <div class="subsection__content" id="subsection_content_<%= idx %>">
-              <ul class="subsection__list">
-                <% link_group.linked_items.each do |linked_item| %>
-                  <li class="subsection__list-item">
-                    <%= link_to linked_item.label, linked_item.href %>
-                  </li>
-                <% end %>
-              </ul>
-            </div>
-          </div>
-
-        <% end %>
-
+          <% end %>
+        </div>
       </div>
-    </div>
   </div>
 
   <div class="column-third">

--- a/test/integration/service_manual_topic_test.rb
+++ b/test/integration/service_manual_topic_test.rb
@@ -55,4 +55,12 @@ class ServiceManualTopicTest < ActionDispatch::IntegrationTest
       assert page.has_css?(".subsection__button")
     end
   end
+
+  test "it does not use the accordion or section headings if the topic does not use sections" do
+    # 'not using sections' == having one section with no title or description
+    setup_and_visit_example('service_manual_topic', 'service_manual_topic_without_sections')
+
+    refute page.has_css?(".subsection__button")
+    refute page.has_css?(".subsection__header")
+  end
 end


### PR DESCRIPTION
Some topics have been configured with only one section which has neither a name nor a description. From a presentation point of view, we treat those topics as if they are 'sectionless'.

Previously the front-end did not handle that case very well – it still rendered a heading for the section, including a heading and description. This lead to blank h2s which is bad from an accessibility point of view (and also just not a great thing to do)

Now, for topics where there is exactly one section AND that section does not have a title, we skip the header and just output a list of links.