### PR TITLE
Display public_updated_at to user for guides

### DIFF
--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -1,7 +1,6 @@
 class ServiceManualGuidePresenter < ContentItemPresenter
   ContentOwner = Struct.new(:title, :href)
 
-  include ActionView::Helpers::DateHelper
   attr_reader :body, :publish_time, :header_links
 
   def initialize(content_item)
@@ -15,10 +14,6 @@ class ServiceManualGuidePresenter < ContentItemPresenter
     links_content_owners_attributes.map do |content_owner_attributes|
       ContentOwner.new(content_owner_attributes["title"], content_owner_attributes["base_path"])
     end
-  end
-
-  def last_published_time_in_words
-    "#{time_ago_in_words(updated_at)} ago"
   end
 
   def category_title
@@ -36,11 +31,11 @@ class ServiceManualGuidePresenter < ContentItemPresenter
     !!details['show_description']
   end
 
-private
-
-  def updated_at
-    DateTime.parse(content_item["updated_at"])
+  def public_updated_at
+    content_item["public_updated_at"].to_time
   end
+
+private
 
   def links_content_owners_attributes
     content_item.to_hash.fetch('links', {}).fetch('content_owners', [])

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -50,7 +50,7 @@
         <% end %>
         <dt>Last updated:</dt>
         <dd>
-          <%= @content_item.last_published_time_in_words %>
+          <%= time_ago_in_words(@content_item.public_updated_at) %> ago
         </dd>
       </dl>
     </div>

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -1,6 +1,16 @@
 require 'test_helper'
 
 class ServiceManualGuideTest < ActionDispatch::IntegrationTest
+  test "shows the time it was published at" do
+    travel_to("2015-10-10") do
+      setup_and_visit_example('service_manual_guide', 'service_manual_guide')
+
+      within('.metadata') do
+        assert page.has_content?('about 16 hours ago')
+      end
+    end
+  end
+
   test "service manual guide shows content owners" do
     setup_and_visit_example('service_manual_guide', 'service_manual_guide')
 

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -12,11 +12,6 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     assert content_owner.href.present?
   end
 
-  test '#last_published_time_in_words outputs a human readable definition of time ago' do
-    guide = presented_guide('updated_at' => 1.year.ago.iso8601)
-    assert_equal 'about 1 year ago', guide.last_published_time_in_words
-  end
-
   test 'breadcrumbs have a root and a topic link' do
     guide = presented_guide
     assert_equal [


### PR DESCRIPTION
https://trello.com/c/7bdchGKi/383-a-guide-s-last-updated-time-updates-each-time-a-topic-is-published

The public_updated_at time is the user facing timestamp to hopefully represent the last major published at time. The updated_at time, which we were using, is updated if a related thing, a topic in this case, updates it.

Move the use of time_ago_in_words into the view and test at the integration level. Testing the rails helper at the unit didn't provide much more confidence than the framework tests give us and this way we can check the timestamp is actually on the page.