### PR TITLE
[DO NOT MERGE] Move the service standard points to the expanded links

### DIFF
--- a/app/assets/stylesheets/modules/_page-header.scss
+++ b/app/assets/stylesheets/modules/_page-header.scss
@@ -6,7 +6,7 @@
 //   <p class="page-header__summary">
 //     How to work in an agile way: principles, tools and governance.
 //   </p>
-//   <p class="page-header__description">
+//   <p class="page-header__intro">
 //     Additional descriptive text can sit here
 //   </p>
 // </div>
@@ -35,7 +35,7 @@
     @include responsive-bottom-margin;
   }
 
-  &__description {
+  &__intro {
     @include core-19;
   }
 

--- a/app/presenters/service_manual_service_standard_presenter.rb
+++ b/app/presenters/service_manual_service_standard_presenter.rb
@@ -13,17 +13,17 @@ class ServiceManualServiceStandardPresenter < ContentItemPresenter
 private
 
   def points_attributes
-    @_points_attributes ||= details["points"] || []
+    @_points_attributes ||= expanded_links["children"] || []
   end
 
-  def details
-    @_details ||= content_item["details"] || {}
+  def expanded_links
+    @_expanded_links ||= content_item["expanded_links"] || {}
   end
 
   class Point
     include Comparable
 
-    attr_reader :title, :summary, :base_path
+    attr_reader :title, :description, :base_path
 
     def self.load(points_attributes)
       points_attributes.map { |point_attributes| new(point_attributes) }
@@ -31,7 +31,7 @@ private
 
     def initialize(attributes)
       @title = attributes["title"]
-      @summary = attributes["summary"]
+      @description = attributes["description"]
       @base_path = attributes["base_path"]
     end
 

--- a/app/presenters/service_manual_service_standard_presenter.rb
+++ b/app/presenters/service_manual_service_standard_presenter.rb
@@ -13,11 +13,11 @@ class ServiceManualServiceStandardPresenter < ContentItemPresenter
 private
 
   def points_attributes
-    @_points_attributes ||= expanded_links["children"] || []
+    @_points_attributes ||= links["children"] || []
   end
 
-  def expanded_links
-    @_expanded_links ||= content_item["expanded_links"] || {}
+  def links
+    @_links ||= content_item["links"] || {}
   end
 
   class Point

--- a/app/views/content_items/service_manual_service_standard.html.erb
+++ b/app/views/content_items/service_manual_service_standard.html.erb
@@ -14,9 +14,9 @@
     <div class="page-header">
       <h1 class="page-header__title"><%= @content_item.title %></h1>
       <p class="page-header__summary">
-        <%= @content_item.content_item["details"]["introduction"] %>
+        <%= @content_item.content_item["description"] %>
       </p>
-      <p class="page-header__description">
+      <p class="page-header__intro">
         <%= @content_item.content_item["details"]["body"] %>
       </p>
     </div>

--- a/app/views/content_items/service_manual_service_standard.html.erb
+++ b/app/views/content_items/service_manual_service_standard.html.erb
@@ -33,7 +33,7 @@
         <h2 class="service-standard-point__title"><%= point.title %></h2>
 
         <div class="service-standard-point__details">
-          <p><%= point.summary %></p>
+          <p><%= point.description %></p>
           <p class="service-standard-point__link"><%= link_to "Read more about point #{ point.number }", point.base_path %></p>
         </div>
       </div>

--- a/test/integration/service_manual_service_standard_test.rb
+++ b/test/integration/service_manual_service_standard_test.rb
@@ -1,10 +1,12 @@
 require 'test_helper'
 
 class ServiceManualServiceStandardTest < ActionDispatch::IntegrationTest
-  test "service standard page has a title" do
+  test "service standard page has a title, summary and intro" do
     setup_and_visit_example('service_manual_service_standard', 'service_manual_service_standard')
 
-    assert page.has_content?("Digital Service Standard"), "No title found"
+    assert page.has_css?(".page-header__title", text: "Digital Service Standard"), "No title found"
+    assert page.has_css?(".page-header__summary", text: "The Digital Service Standard is a set of 18 criteria"), "No description found"
+    assert page.has_css?(".page-header__intro", text: "All public facing transactional services must meet the standard."), "No body found"
   end
 
   test "service standard page has points" do

--- a/test/integration/service_manual_service_standard_test.rb
+++ b/test/integration/service_manual_service_standard_test.rb
@@ -10,18 +10,24 @@ class ServiceManualServiceStandardTest < ActionDispatch::IntegrationTest
   test "service standard page has points" do
     setup_and_visit_example('service_manual_service_standard', 'service_manual_service_standard')
 
-    assert_equal 2, points.length
+    assert_equal 3, points.length
 
     within(points[0]) do
       assert page.has_content?("1. Understand user needs"), "Point not found"
-      assert page.has_content?("Summary goes here"), "Summary not found"
+      assert page.has_content?(/Research to develop a deep knowledge/), "Description not found"
       assert page.has_link?("Read more about point 1", href: "/service-manual/service-standard/understand-user-needs"), "Link not found"
     end
 
     within(points[1]) do
       assert page.has_content?("2. Do ongoing user research"), "Point not found"
-      assert page.has_content?("Another summary goes here"), "Summary not found"
+      assert page.has_content?(/Put a plan in place/), "Description not found"
       assert page.has_link?("Read more about point 2", href: "/service-manual/service-standard/do-ongoing-user-research"), "Link not found"
+    end
+
+    within(points[2]) do
+      assert page.has_content?("3. Have a multidisciplinary team"), "Point not found"
+      assert page.has_content?(/Put in place a sustainable multidisciplinary/), "Description not found"
+      assert page.has_link?("Read more about point 3", href: "/service-manual/service-standard/have-a-multidisciplinary-team"), "Link not found"
     end
   end
 
@@ -34,6 +40,10 @@ class ServiceManualServiceStandardTest < ActionDispatch::IntegrationTest
 
     within('div[id="criterion-2"]') do
       assert page.has_content?("2. Do ongoing user research"), "Anchor is incorrect"
+    end
+
+    within('div[id="criterion-3"]') do
+      assert page.has_content?("3. Have a multidisciplinary team"), "Anchor is incorrect"
     end
   end
 

--- a/test/presenters/service_manual_service_standard_presenter_test.rb
+++ b/test/presenters/service_manual_service_standard_presenter_test.rb
@@ -15,7 +15,7 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
 
   test "#points returns points ordered numerically" do
     content_item_hash = {
-      "expanded_links" => {
+      "links" => {
         "children" => [
           { "title" => "3. Title" },
           { "title" => "1. Title" },

--- a/test/presenters/service_manual_service_standard_presenter_test.rb
+++ b/test/presenters/service_manual_service_standard_presenter_test.rb
@@ -15,8 +15,8 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
 
   test "#points returns points ordered numerically" do
     content_item_hash = {
-      "details" => {
-        "points" => [
+      "expanded_links" => {
+        "children" => [
           { "title" => "3. Title" },
           { "title" => "1. Title" },
           { "title" => "9. Title" },


### PR DESCRIPTION
On hold until we work out if we're allowed to use the expanded_links.

The points have been moved from into the expanded_links hash as an improvement to the code.