### PR TITLE
Use existing vars from the govuk frontend toolkit

### DIFF
--- a/app/assets/stylesheets/modules/_service-standard-point.scss
+++ b/app/assets/stylesheets/modules/_service-standard-point.scss
@@ -1,7 +1,6 @@
 .service-standard-point {
 
-  $point-gutter: 30px;
-  $point-gutter-tablet: 45px;
+  $gutter-tablet: ($gutter * 1.5);  // 45px
 
   border-top: 1px solid $border-colour;
   margin-top: 1.5em;
@@ -10,29 +9,29 @@
   &__title {
     @include bold-24;
     margin-bottom: 0.5em;
-    margin-left: $point-gutter;
+    margin-left: $gutter;
 
     @include media(tablet) {
-      margin-left: $point-gutter-tablet;
+      margin-left: $gutter-tablet;
     }
   }
 
   &__number {
     float: left;
-    margin-left: -$point-gutter;
+    margin-left: -$gutter;
 
     @include media(tablet) {
-      margin-left: -$point-gutter-tablet;
+      margin-left: -$gutter-tablet;
     }
   }
 
   &__details {
     @include core-19;
     margin-bottom: 0.5em;
-    margin-left: $point-gutter;
+    margin-left: $gutter;
 
     @include media(tablet) {
-      margin-left: $point-gutter-tablet;
+      margin-left: $gutter-tablet;
     }
   }
 


### PR DESCRIPTION
$gutter = 30px is [already defined in the frontend toolkit](
https://github.com/alphagov/govuk_frontend_toolkit/blob/master/styleshee
ts/_measurements.scss).

Use this, and create `$gutter-tablet` from this.

For a later PR:
It would be better to use em here, as we're using em for top and bottom margins on this module.
This can form part of another piece of work to ensure we're using consistent units.