### PR TITLE
Timestamp for first draft

### DIFF
--- a/app/presenters/service_manual_guide_presenter.rb
+++ b/app/presenters/service_manual_guide_presenter.rb
@@ -33,14 +33,20 @@ class ServiceManualGuidePresenter < ContentItemPresenter
   end
 
   def public_updated_at
-    content_item["public_updated_at"].to_time
+    timestamp = content_item["public_updated_at"]
+
+    timestamp.to_time if timestamp
+  end
+
+  def visible_updated_at
+    public_updated_at || updated_at
   end
 
   def latest_change
     change = change_history.first
     if change.present?
       Change.new(
-        public_updated_at,
+        visible_updated_at,
         change["note"],
         change["reason_for_change"]
       )
@@ -85,5 +91,9 @@ private
 
   def change_history
     @_change_history ||= details.fetch("change_history", {})
+  end
+
+  def updated_at
+    content_item["updated_at"].to_time
   end
 end

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -50,7 +50,7 @@
         <% end %>
         <dt>Last updated:</dt>
         <dd>
-          <%= time_ago_in_words(@content_item.public_updated_at) %> ago
+          <%= time_ago_in_words(@content_item.visible_updated_at) %> ago
         </dd>
       </dl>
     </div>

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -1,6 +1,27 @@
 require 'test_helper'
 
 class ServiceManualGuideTest < ActionDispatch::IntegrationTest
+  test "shows the time it was saved and it hasn't been published yet" do
+    now = "2015-10-10T09:00:00+00:00"
+    last_saved_at = "2015-10-10T08:55:00+00:00"
+
+    travel_to(now) do
+      example = get_content_example_by_format_and_name(
+        'service_manual_guide',
+        'service_manual_guide',
+        'updated_at' => last_saved_at
+      )
+      base_path = example.fetch('base_path')
+      example.delete('public_updated_at')
+      content_store_has_item(base_path, example)
+      visit base_path
+
+      within('.metadata') do
+        assert page.has_content?('5 minutes ago')
+      end
+    end
+  end
+
   test "shows the time it was published at" do
     travel_to("2015-10-10") do
       setup_and_visit_example('service_manual_guide', 'service_manual_guide')

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class ServiceManualGuideTest < ActionDispatch::IntegrationTest
-  test "shows the time it was saved and hasn't been published yet" do
+  test "shows the time it was saved if it hasn't been published yet" do
     now = "2015-10-10T09:00:00+00:00"
     last_saved_at = "2015-10-10T08:55:00+00:00"
 
@@ -23,7 +23,7 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "shows the time it was published at" do
+  test "shows the time it was published if it has been published" do
     travel_to("2015-10-10") do
       setup_and_visit_example('service_manual_guide', 'service_manual_guide')
 

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -1,18 +1,19 @@
 require 'test_helper'
 
 class ServiceManualGuideTest < ActionDispatch::IntegrationTest
-  test "shows the time it was saved and it hasn't been published yet" do
+  test "shows the time it was saved and hasn't been published yet" do
     now = "2015-10-10T09:00:00+00:00"
     last_saved_at = "2015-10-10T08:55:00+00:00"
 
     travel_to(now) do
-      example = govuk_content_schema_example(
-        'service_manual_guide',
-        'service_manual_guide',
-        'updated_at' => last_saved_at
+      example = simulate_example_as_first_edition_on_draft_stack(
+        govuk_content_schema_example(
+          'service_manual_guide',
+          'service_manual_guide',
+          'updated_at' => last_saved_at
+        )
       )
       base_path = example.fetch('base_path')
-      example.delete('public_updated_at')
       content_store_has_item(base_path, example)
       visit base_path
 

--- a/test/integration/service_manual_guide_test.rb
+++ b/test/integration/service_manual_guide_test.rb
@@ -6,7 +6,7 @@ class ServiceManualGuideTest < ActionDispatch::IntegrationTest
     last_saved_at = "2015-10-10T08:55:00+00:00"
 
     travel_to(now) do
-      example = get_content_example_by_format_and_name(
+      example = govuk_content_schema_example(
         'service_manual_guide',
         'service_manual_guide',
         'updated_at' => last_saved_at

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -113,6 +113,22 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     assert_equal expected_history, presented_guide.latest_change
   end
 
+  test "#latest_change timestamp is the updated_at time if public_updated_at hasn't been set" do
+    expected_history = ServiceManualGuidePresenter::Change.new(
+      "2015-10-07T09:00:00+00:00".to_time,
+      "This is our latest change",
+      "This is the reason for our latest change"
+    )
+
+    timestamp = '2015-10-07T09:00:00+00:00'
+    example = govuk_content_schema_example('service_manual_guide', 'service_manual_guide')
+    example.delete('public_updated_at')
+    example["updated_at"] = timestamp
+    guide = ServiceManualGuidePresenter.new(example)
+
+    assert_equal expected_history, guide.latest_change
+  end
+
   test '#previous_changes returns the change history for the guide' do
     expected_history = [
       ServiceManualGuidePresenter::Change.new(

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -79,8 +79,9 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
   end
 
   test "#public_updated_at returns nil if not available" do
-    example = govuk_content_schema_example('service_manual_guide', 'service_manual_guide')
-    example.delete('public_updated_at')
+    example = simulate_example_as_first_edition_on_draft_stack(
+      govuk_content_schema_example('service_manual_guide', 'service_manual_guide')
+    )
     guide = ServiceManualGuidePresenter.new(example)
 
     assert_nil guide.public_updated_at
@@ -95,9 +96,13 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
 
   test "#visible_updated_at returns the updated_at time if the public_updated_at hasn't yet been set" do
     timestamp = '2015-10-10T09:00:00+00:00'
-    example = govuk_content_schema_example('service_manual_guide', 'service_manual_guide')
-    example.delete('public_updated_at')
-    example["updated_at"] = timestamp
+    example = simulate_example_as_first_edition_on_draft_stack(
+      govuk_content_schema_example(
+        'service_manual_guide',
+        'service_manual_guide',
+        'updated_at' => timestamp
+      )
+    )
     guide = ServiceManualGuidePresenter.new(example)
 
     assert_equal guide.visible_updated_at, timestamp.to_time
@@ -114,17 +119,21 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
   end
 
   test "#latest_change timestamp is the updated_at time if public_updated_at hasn't been set" do
+    timestamp = '2015-10-07T09:00:00+00:00'
+    example = simulate_example_as_first_edition_on_draft_stack(
+      govuk_content_schema_example(
+        'service_manual_guide',
+        'service_manual_guide',
+        'updated_at' => timestamp
+      )
+    )
+    guide = ServiceManualGuidePresenter.new(example)
+
     expected_history = ServiceManualGuidePresenter::Change.new(
-      "2015-10-07T09:00:00+00:00".to_time,
+      timestamp.to_time,
       "This is our latest change",
       "This is the reason for our latest change"
     )
-
-    timestamp = '2015-10-07T09:00:00+00:00'
-    example = govuk_content_schema_example('service_manual_guide', 'service_manual_guide')
-    example.delete('public_updated_at')
-    example["updated_at"] = timestamp
-    guide = ServiceManualGuidePresenter.new(example)
 
     assert_equal expected_history, guide.latest_change
   end

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -74,6 +74,17 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
     refute ServiceManualGuidePresenter.new({}).show_description?
   end
 
+  test "#public_updated_at returns a time" do
+    assert_kind_of Time, presented_guide.public_updated_at
+  end
+
+  test "#public_updated_at returns nil if not available" do
+    example = govuk_content_schema_example('service_manual_guide', 'service_manual_guide')
+    example.delete('public_updated_at')
+
+    assert_nil ServiceManualGuidePresenter.new(example).public_updated_at
+  end
+
   test '#latest_change returns the details for the most recent change' do
     expected_history = ServiceManualGuidePresenter::Change.new(
       "2015-10-09T08:17:10+00:00".to_time,

--- a/test/presenters/service_manual_guide_presenter_test.rb
+++ b/test/presenters/service_manual_guide_presenter_test.rb
@@ -81,8 +81,26 @@ class ServiceManualGuidePresenterTest < ActiveSupport::TestCase
   test "#public_updated_at returns nil if not available" do
     example = govuk_content_schema_example('service_manual_guide', 'service_manual_guide')
     example.delete('public_updated_at')
+    guide = ServiceManualGuidePresenter.new(example)
 
-    assert_nil ServiceManualGuidePresenter.new(example).public_updated_at
+    assert_nil guide.public_updated_at
+  end
+
+  test "#visible_updated_at returns the public_updated_at" do
+    timestamp = '2015-10-10T09:00:00+00:00'
+    guide = presented_guide('public_updated_at' => timestamp)
+
+    assert_equal guide.visible_updated_at, timestamp.to_time
+  end
+
+  test "#visible_updated_at returns the updated_at time if the public_updated_at hasn't yet been set" do
+    timestamp = '2015-10-10T09:00:00+00:00'
+    example = govuk_content_schema_example('service_manual_guide', 'service_manual_guide')
+    example.delete('public_updated_at')
+    example["updated_at"] = timestamp
+    guide = ServiceManualGuidePresenter.new(example)
+
+    assert_equal guide.visible_updated_at, timestamp.to_time
   end
 
   test '#latest_change returns the details for the most recent change' do

--- a/test/support/draft_stack_examples.rb
+++ b/test/support/draft_stack_examples.rb
@@ -1,0 +1,10 @@
+module DraftStackExamples
+  # There are small changes between a content item on the draft stack
+  # and on the live stack. To avoid putting mostly duplicated
+  # examples in govuk-content-schemas with differences that are common
+  # across all schemas, the things that are different can hopefully
+  # be managed in this helper.
+  def simulate_example_as_first_edition_on_draft_stack(hash)
+    hash.except('public_updated_at')
+  end
+end

--- a/test/support/govuk_content_schema_examples.rb
+++ b/test/support/govuk_content_schema_examples.rb
@@ -30,9 +30,10 @@ module GovukContentSchemaExamples
     document
   end
 
-  def govuk_content_schema_example(schema_name, example_name)
-    string = GovukContentSchemaTestHelpers::Examples.new.get(schema_name, example_name)
-    JSON.parse(string)
+  def govuk_content_schema_example(schema_name, example_name, overrides = {})
+    JSON.parse(
+      GovukContentSchemaTestHelpers::Examples.new.get(schema_name, example_name)
+    ).deep_merge(overrides.stringify_keys)
   end
 
   module ClassMethods

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,14 +2,16 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'webmock/minitest'
-require 'support/govuk_content_schema_examples'
 require 'capybara/rails'
 require 'capybara/poltergeist'
 require 'slimmer/test'
 require 'slimmer/test_helpers/shared_templates'
 
+Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |file| require file }
+
 class ActiveSupport::TestCase
   include GovukContentSchemaExamples
+  include DraftStackExamples
 end
 
 # Note: This is so that slimmer is skipped, preventing network requests for

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,16 +51,10 @@ class ActionDispatch::IntegrationTest
   end
 
   def setup_and_visit_example(format, name, overrides = {})
-    example = get_content_example_by_format_and_name(format, name, overrides)
+    example = govuk_content_schema_example(format, name, overrides)
     base_path = example.fetch('base_path')
 
     content_store_has_item(base_path, example)
     visit base_path
-  end
-
-  def get_content_example_by_format_and_name(format, name, overrides = {})
-    JSON.parse(
-      GovukContentSchemaTestHelpers::Examples.new.get(format, name)
-    ).deep_merge(overrides.stringify_keys)
   end
 end


### PR DESCRIPTION
https://trello.com/c/DK1xNwvb

The `public_updated_at` timestamp is not available when previewing the first edition. To avoid a bug we fall back on the `updated_at` field which represents the last time the content item was updated _for any reason_ in the content store. In between a user saving a draft and previewing it, this is most likely going to be the time they saved the draft.

If we ever want to get more precise about this timestamp we should start sending `last_edited_at` to the publishing-api.

I've added a test helper for the draft stack examples which is a lot of trumpeting for deleting a single key from a hash. However, organisation wide I think it's still fairly unknown behaviour so it's a good thing to be a little shouty about.