### PR TITLE
Skip Slimmer middleware if running Jasmine specs in browser

### DIFF
--- a/config/initializers/jasmine_rails.rb
+++ b/config/initializers/jasmine_rails.rb
@@ -1,0 +1,1 @@
+require 'jasmine_rails_spec_runner_controller'

--- a/lib/jasmine_rails_spec_runner_controller.rb
+++ b/lib/jasmine_rails_spec_runner_controller.rb
@@ -1,0 +1,13 @@
+# Skip the Slimmer middleware when rendering the Jasmine runner /specs
+# in the browser.
+if defined?(JasmineRails)
+  require 'slimmer/headers'
+
+  module JasmineRails
+    class SpecRunnerController < JasmineRails::ApplicationController
+      include Slimmer::Headers
+
+      before_action -> { set_slimmer_headers(skip: 'true') }
+    end
+  end
+end


### PR DESCRIPTION
This stops the Slimmer middleware being applied when rendering the jasmine runner output in the browser. Without it, the runner output page does not contain a GOV.UK-like page and errors.

After this is merged we can visit http://service-manual-frontend.dev.gov.uk/specs to help debugging.