### PR TITLE
Include list of topics on homepage [DO NOT MERGE]

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @import "modules/change-history";
 @import "modules/govspeak-wrapper";
 @import "modules/hero";
+@import "modules/link-unit";
 @import "modules/main-service-manual";
 @import "modules/metadata";
 @import "modules/notice";

--- a/app/assets/stylesheets/modules/_link-unit.scss
+++ b/app/assets/stylesheets/modules/_link-unit.scss
@@ -1,0 +1,9 @@
+.link-unit {
+  &__title {
+    @include bold-19;
+  }
+
+  &__description {
+    @include core-16($line-height: 1.5);
+  }
+}

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,5 +1,5 @@
 class ContentItemPresenter
-  attr_reader :content_item, :title, :description, :format, :locale, :phase
+  attr_reader :content_item, :title, :description, :format, :locale, :phase, :links
 
   def initialize(content_item)
     @content_item = content_item
@@ -8,10 +8,11 @@ class ContentItemPresenter
     @format = content_item["format"]
     @locale = content_item["locale"] || "en"
     @phase = content_item["phase"]
+    @links = content_item["links"] || {}
   end
 
   def available_translations
-    sorted_locales(@content_item["links"]["available_translations"])
+    sorted_locales(links["available_translations"])
   end
 
 private

--- a/app/presenters/service_manual_homepage_presenter.rb
+++ b/app/presenters/service_manual_homepage_presenter.rb
@@ -2,4 +2,14 @@ class ServiceManualHomepagePresenter < ContentItemPresenter
   def breadcrumbs
     []
   end
+
+  def topics
+    unsorted_topics.sort_by { |topic| topic["title"] }
+  end
+
+private
+
+  def unsorted_topics
+    @_topics ||= links["children"] || []
+  end
 end

--- a/app/presenters/service_manual_service_standard_presenter.rb
+++ b/app/presenters/service_manual_service_standard_presenter.rb
@@ -16,10 +16,6 @@ private
     @_points_attributes ||= links["children"] || []
   end
 
-  def links
-    @_links ||= content_item["links"] || {}
-  end
-
   class Point
     include Comparable
 

--- a/app/views/content_items/service_manual_homepage.html.erb
+++ b/app/views/content_items/service_manual_homepage.html.erb
@@ -26,3 +26,16 @@
     </div>
   </div>
 </header>
+
+<% @content_item.topics.each_slice(3) do |row_of_topics| %>
+  <div class="grid-row">
+  <% row_of_topics.each do |topic| %>
+    <div class="column-one-third">
+      <div class="link-unit">
+        <h2 class="link-unit__title"><%= link_to topic["title"], topic["base_path"] %></h2>
+        <p class="link-unit__description"><%= topic["description"] %></p>
+      </div>
+    </div>
+  <% end %>
+  </div>
+<% end %>

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -19,4 +19,11 @@ class HomepageTest < ActionDispatch::IntegrationTest
 
     assert page.has_link? 'service manual team', href: '/contact/govuk'
   end
+
+  test 'the homepage includes the titles and descriptions of associated topics' do
+    setup_and_visit_example('service_manual_homepage', 'service_manual_homepage')
+
+    assert page.has_content? "Agile delivery How to work in an agile way: principles, tools and governance."
+    assert page.has_link? 'Agile delivery', href: '/service-manual/agile-delivery'
+  end
 end

--- a/test/presenters/service_manual_homepage_presenter_test.rb
+++ b/test/presenters/service_manual_homepage_presenter_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class ServiceManualHomepagePresenterTest < ActiveSupport::TestCase
+  test '#topics returns the children in the links, ordered alphabetically' do
+    homepage = presented_homepage(
+      'links' => {
+        'children' => [
+          { 'title' => "Agile Delivery" },
+          { 'title' => "Helping people to use your service" },
+          { 'title' => "Funding and procurement" }
+        ]
+      }
+    )
+
+    assert_equal(
+      [
+        { 'title' => "Agile Delivery" },
+        { 'title' => "Funding and procurement" },
+        { 'title' => "Helping people to use your service" }
+      ],
+      homepage.topics
+    )
+  end
+
+private
+
+  def presented_homepage(overriden_attributes = {})
+    ServiceManualHomepagePresenter.new(
+      JSON.parse(
+        GovukContentSchemaTestHelpers::Examples.new.get('service_manual_homepage', 'service_manual_homepage')
+      ).merge(overriden_attributes)
+    )
+  end
+end


### PR DESCRIPTION
This branch is built off of `homepage-intro-and-search`. Once that branch has merged, the target for this branch can be updated to `homepage`.
