### PR TITLE
Add meta descriptions

### DIFF
--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, "service-manual" %>
 <%= content_for :title, "#{@content_item.title} - Digital Service Manual" %>
+<% content_for :meta_description, @content_item.description %>
 
 <% content_for :phase_message do %>
   <%= render 'shared/service_manual_custom_phase_message', phase: @content_item.phase %>

--- a/app/views/content_items/service_manual_service_standard.html.erb
+++ b/app/views/content_items/service_manual_service_standard.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :page_class, "service-manual" %>
 <%= content_for :title, "#{@content_item.title} - Digital Service Manual" %>
+<% content_for :meta_description, @content_item.content_item["description"] %>
 
 <% content_for :phase_message do %>
   <%= render 'shared/service_manual_custom_phase_message', phase: @content_item.phase %>

--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -1,13 +1,12 @@
 <%= content_for :page_class, "service-manual" %>
 <%= content_for :title, "#{@content_item.title} - Digital Service Manual" %>
+<% content_for :meta_description, @content_item.description %>
 
 <% content_for :phase_message do %>
   <%= render 'shared/service_manual_custom_phase_message', phase: @content_item.phase %>
 <% end %>
 
 <%= render 'govuk_component/breadcrumbs', breadcrumbs: @content_item.breadcrumbs %>
-
-<% content_for :meta_description, @content_item.description %>
 
 <div class="grid-row">
   <div class="column-two-thirds">


### PR DESCRIPTION
The meta description tag is used for the index page of the service manual but none of the sub-pages. This commit adds meta description tags to all pages, the contents of which are set to the description associated with the relevant part of the service manual. This adds descriptions to external search engine results when the pages are re-indexed.

Trello: https://trello.com/c/bbAwFAQ1/108-add-meta-descriptions-to-pages-missing-them