### PR TITLE
[Do not merge, demo only] Add sticky nav

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,4 +5,4 @@
 //= require_tree .
 
 window.GOVUK.stickAtTopWhenScrolling.init();
-window.GOVUK.stopScrollingAtFooter.init();
+window.GOVUK.stopScrollingAtFooter.addEl($('.page-contents'));

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,6 @@
 // from govuk_frontend_toolkit
-//= require govuk/stick-at-top-when-scrolling
+//= require stick-at-top-when-scrolling
 //= require govuk/stop-scrolling-at-footer
-
 //= require_tree .
 
 window.GOVUK.stickAtTopWhenScrolling.init();

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,8 @@
+// from govuk_frontend_toolkit
+//= require govuk/stick-at-top-when-scrolling
+//= require govuk/stop-scrolling-at-footer
+
 //= require_tree .
+
+window.GOVUK.stickAtTopWhenScrolling.init();
+window.GOVUK.stopScrollingAtFooter.init();

--- a/app/assets/javascripts/stick-at-top-when-scrolling.js
+++ b/app/assets/javascripts/stick-at-top-when-scrolling.js
@@ -1,0 +1,125 @@
+(function (global) {
+  "use strict";
+
+  var $ = global.jQuery;
+  var GOVUK = global.GOVUK || {};
+
+  // Stick elements to top of screen when you scroll past, documentation is in the README.md
+  var sticky = {
+    _hasScrolled: false,
+    _scrollTimeout: false,
+    _hasResized: false,
+    _resizeTimeout: false,
+
+    getWindowDimensions: function() {
+      return {
+        height: $(global).height(),
+        width: $(global).width()
+      };
+    },
+    getWindowPositions: function() {
+      return {
+        scrollTop: $(global).scrollTop()
+      };
+    },
+    getElementOffset: function($el) {
+      return $el.offset()
+    },
+    init: function(){
+      var $els = $('.js-stick-at-top-when-scrolling');
+
+      if($els.length > 0){
+        sticky.$els = $els;
+
+        if(sticky._scrollTimeout === false) {
+          $(global).scroll(sticky.onScroll);
+          sticky._scrollTimeout = global.setInterval(sticky.checkScroll, 50);
+        }
+
+        if(sticky._resizeTimeout === false) {
+          $(global).resize(sticky.onResize);
+          sticky._resizeTimeout = global.setInterval(sticky.checkResize, 50);
+        }
+
+      }
+      if(GOVUK.stopScrollingAtFooter){
+        $els.each(function(i,el){
+          var $img = $(el).find('img');
+          if($img.length > 0){
+            var image = new Image();
+            image.onload = function(){
+              GOVUK.stopScrollingAtFooter.addEl($(el), $(el).outerHeight());
+            };
+            image.src = $img.attr('src');
+          } else {
+            GOVUK.stopScrollingAtFooter.addEl($(el), $(el).outerHeight());
+          }
+        });
+      }
+    },
+    onScroll: function(){
+      sticky._hasScrolled = true;
+    },
+    onResize: function(){
+      sticky._hasResized = true;
+    },
+    checkScroll: function(){
+      if(sticky._hasScrolled === true){
+        sticky._hasScrolled = false;
+
+        var windowVerticalPosition = sticky.getWindowPositions().scrollTop;
+        var windowDimensions = sticky.getWindowDimensions();
+        console.log("checkScroll width:" +windowDimensions.width);
+
+        sticky.$els.each(function(i, el){
+          var $el = $(el),
+              scrolledFrom = $el.data('scrolled-from');
+
+          if (scrolledFrom && windowVerticalPosition < scrolledFrom){
+            console.log('release');
+            sticky.release($el);
+          } else if(windowDimensions.width > 768 && windowVerticalPosition >= sticky.getElementOffset($el).top) {
+            sticky.stick($el);
+            console.log('stick');
+          }
+        });
+      }
+    },
+    checkResize: function() {
+      if(sticky._hasResized === true){
+        sticky._hasResized = false;
+
+        var windowDimensions = sticky.getWindowDimensions();
+        console.log("checkScroll width:" +windowDimensions.width);
+
+        sticky.$els.each(function(i, el){
+          var $el = $(el),
+           scrolledFrom = $el.data('scrolled-from');
+
+          if(windowDimensions.width <= 768) {
+            sticky.release($el);
+            console.log('release - less than 768');
+          }
+
+        });
+      }
+    },
+    stick: function($el){
+      if (!$el.hasClass('content-fixed')) {
+        $el.data('scrolled-from', sticky.getElementOffset($el).top);
+        var height = Math.max($el.height(), 1);
+        $el.before('<div class="shim" style="width: '+ $el.width() + 'px; height: ' + height + 'px">&nbsp;</div>');
+        $el.css('width', $el.width() + "px").addClass('content-fixed');
+      }
+    },
+    release: function($el){
+      if($el.hasClass('content-fixed')){
+        $el.data('scrolled-from', false);
+        $el.removeClass('content-fixed').css('width', '');
+        $el.siblings('.shim').remove();
+      }
+    }
+  };
+  GOVUK.stickAtTopWhenScrolling = sticky;
+  global.GOVUK = GOVUK;
+})(window);

--- a/app/assets/stylesheets/modules/_page-contents.scss
+++ b/app/assets/stylesheets/modules/_page-contents.scss
@@ -3,6 +3,7 @@
 
   @include media(tablet) {
     margin-top: 2em;
+    padding-bottom: 2em;
   }
 
   &__title {

--- a/app/views/content_items/service_manual_guide.html.erb
+++ b/app/views/content_items/service_manual_guide.html.erb
@@ -63,7 +63,7 @@
   <div class="column-third">
 
     <!--  Page contents -->
-    <div class="page-contents">
+    <div class="page-contents js-stick-at-top-when-scrolling">
       <h2 class="page-contents__title">Page contents:</h2>
       <ul class="page-contents__list">
         <% @content_item.header_links.each do |header_link| %>


### PR DESCRIPTION
This is a branch to demo [GOVUK.StickAtTopWhenScrolling](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/stick-at-top-when-scrolling.js).

Steps for this PR:

- [ ] Merge the changes to GOVUK.StickAtTopWhenScrolling in the govuk_frontend_toolkit
- [ ] Bump the version of the govuk_frontend_toolkit
- [ ] Update the version of the govuk_frontend_toolkit that service-manual-frontend is using
- [ ] Remove the duplicate stick-at-top-when-scrolling.js copied to this repo in `app/assets/javascripts`

Closing in favour of #61.