### PR TITLE
Bump the govuk frontend toolkit to 4.18.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby File.read(".ruby-version").strip
 
 gem 'airbrake', '4.0'
-gem 'govuk_frontend_toolkit', '4.10.0'
+gem 'govuk_frontend_toolkit', '4.18.3'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'
 gem 'rails', '4.2.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     govuk-lint (0.6.1)
       rubocop (~> 0.35.0)
       scss_lint (~> 0.44.0)
-    govuk_frontend_toolkit (4.10.0)
+    govuk_frontend_toolkit (4.18.3)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     http-cookie (1.0.2)
@@ -274,7 +274,7 @@ DEPENDENCIES
   gds-api-adapters (= 27.0.0)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
-  govuk_frontend_toolkit (= 4.10.0)
+  govuk_frontend_toolkit (= 4.18.3)
   jasmine-rails
   logstasher (= 0.6.1)
   phantomjs (~> 1.9.7)


### PR DESCRIPTION
Update the Gemfile to use the most recent version of the govuk_frontend_toolkit.

4.18.3 is the change we're interested in, to finish the work on #61. 

This will include the following changes:

https://github.com/alphagov/govuk_frontend_toolkit/blob/master/CHANGELOG
.md

# 4.18.3

- For smaller screens (<768px) ensure that the
GOVUK.StickAtTopWhenScrolling JS "unsticks" the element which was
previously "stuck" (by removing both the class which sets fixed
positioning and the shim). ([PR
#329](https://github.com/alphagov/govuk_frontend_toolkit/pull/329))

# 4.18.2

- Remove unnecessary print font fallback that causes regression
downstream ([PR
#328](https://github.com/alphagov/govuk_frontend_toolkit/pull/328))
- Update tooling to use npm script rather than grunt-shell ([PR
#327](https://github.com/alphagov/govuk_frontend_toolkit/pull/327))

# 4.18.1

- Fix error in IE - remove trailing comma from shimLinksWithButtonRole
JavaScript ([PR
#323](https://github.com/alphagov/govuk_frontend_toolkit/pull/323)).

# 4.18.0

- Add GOVUK.ShowHideContent JavaScript to support showing and hiding
content, toggled by radio buttons and checkboxes ([PR
#315](https://github.com/alphagov/govuk_frontend_toolkit/pull/315)).

# 4.17.0

- SelectionButtons will add a class to the label with the type of the
child input ([PR
#317](https://github.com/alphagov/govuk_frontend_toolkit/pull/317))

# 4.16.1

- Fix anchor-buttons.js to trigger a native click event, also rename to
shimLinksWithButtonRole.js to explain what it does
- Add tests for shimLinksWithButtonRole ([PR
#310](https://github.com/alphagov/govuk_frontend_toolkit/pull/310))

# 4.16.0

- Add Department for International Trade organisation ([PR
#308](https://github.com/alphagov/govuk_frontend_toolkit/pull/308))

# 4.15.0

- Add support for Google Analytics fieldsObject ([PR
#298](https://github.com/alphagov/govuk_frontend_toolkit/pull/298))
- anchor-buttons.js: normalise keyboard behaviour between buttons and
links with a button role ([PR
#297](https://github.com/alphagov/govuk_frontend_toolkit/pull/297))

# 4.14.1

- Fix tabular number sizing in Firefox ([PR
#301](https://github.com/alphagov/govuk_frontend_toolkit/pull/301))

# 4.14.0

- Allow use of multiple GA customDimensionIndex. See [this
section](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/
docs/javascript.md#using-google-custom-dimensions-with-your-own-statisti
cal-model) of the documentation for more information.
- Configurable duration (in days) for AB Test cookie. See [this
section](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/
docs/javascript.md#multivariate-test-framework) of the documentation
for more information.
- Allow base scripts to run within a module loader. See [this
PR](https://github.com/alphagov/govuk_frontend_toolkit/pull/290) for
more information.

# 4.13.0

- Make headings block-level by default (PR #200). If you are styling
elements you want to be inline with heading includes, you’ll need to
explicitly make them inline in your CSS.

# 4.12.0

- Increase button padding to match padding from GOV.UK elements (PR
#275).
If you have UI which depends on the padding set by the button mixin in
the frontend toolkit and this is not overridden by button padding set
by GOV.UK elements, this change will affect it.

# 4.11.0

- Remove the GDS-Logo font-face definition (PR #272)
- Move the @viewport statements to govuk_template (PR #272). If you
upgrade to this version of govuk_frontend_toolkit and you’re also using
govuk_template you’ll need to upgrade that to at least 0.17.2 to
maintain compatibility with desktop IE10 in snap mode.