### PR TITLE
Link to service standard email alert signup

### DIFF
--- a/app/presenters/service_manual_service_standard_presenter.rb
+++ b/app/presenters/service_manual_service_standard_presenter.rb
@@ -10,6 +10,11 @@ class ServiceManualServiceStandardPresenter < ContentItemPresenter
     ]
   end
 
+  def email_alert_signup_link
+    signups = content_item['links'].fetch('email_alert_signup', [])
+    signups.first['base_path'] if signups.any?
+  end
+
 private
 
   def points_attributes

--- a/app/views/content_items/service_manual_service_standard.html.erb
+++ b/app/views/content_items/service_manual_service_standard.html.erb
@@ -43,4 +43,19 @@
       </div>
     <% end %>
   </div>
+
+  <div class="column-third">
+    <aside class="related">
+    <% if @content_item.email_alert_signup_link.present? %>
+      <div class="related-item">
+        <h2 class="related-item__title" id="related-subscriptions">
+          Get notifications
+        </h2>
+        <p class="related-item__description">When any points in the Digital Service Standard are updated
+          <%= link_to "email", @content_item.email_alert_signup_link, class: 'related-item__email-link' %>
+        </p>
+      </div>
+    <% end %>
+    </aside>
+  </div>
 </div>

--- a/test/integration/service_manual_service_standard_test.rb
+++ b/test/integration/service_manual_service_standard_test.rb
@@ -49,6 +49,13 @@ class ServiceManualServiceStandardTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "it includes a link to subscribe for email alerts" do
+    setup_and_visit_example('service_manual_service_standard', 'service_manual_service_standard')
+
+    assert page.has_link?("email",
+      href: "/service-manual/service-standard/email-signup")
+  end
+
   def points
     find_all('.service-standard-point')
   end

--- a/test/presenters/service_manual_service_standard_presenter_test.rb
+++ b/test/presenters/service_manual_service_standard_presenter_test.rb
@@ -2,12 +2,7 @@ require 'test_helper'
 
 class ContentItemPresenterTest < ActiveSupport::TestCase
   test "#points gets points from the details" do
-    example = GovukContentSchemaTestHelpers::Examples.new.get(
-      'service_manual_service_standard',
-      'service_manual_service_standard'
-    )
-
-    points = ServiceManualServiceStandardPresenter.new(JSON.parse(example)).points
+    points = presented_standard.points
 
     assert points.any? { |point_hash| point_hash.title == "1. Understand user needs" }
     assert points.any? { |point_hash| point_hash.title == "2. Do ongoing user research" }
@@ -64,5 +59,29 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
         { title: "Service manual", url: "/service-manual" },
         { title: "Digital Service Standard" },
       ]
+  end
+
+  test '#email_alert_signup returns a link to the email alert signup' do
+    assert_equal "/service-manual/service-standard/email-signup",
+      presented_standard.email_alert_signup_link
+  end
+
+  test '#email_alert_signup does not error if no signup exists' do
+    assert_equal nil,
+      presented_standard(links: { email_alert_signup: [] }).email_alert_signup_link
+  end
+
+private
+
+  def presented_standard(overriden_attributes = {})
+    example = GovukContentSchemaTestHelpers::Examples.new.get(
+      'service_manual_service_standard',
+      'service_manual_service_standard'
+    )
+
+    example_with_overrides = JSON.parse(example)
+      .merge(overriden_attributes.with_indifferent_access)
+
+    ServiceManualServiceStandardPresenter.new(example_with_overrides)
   end
 end


### PR DESCRIPTION
Include a link to the email alert signup page for the service standard.

Related schemas change: https://github.com/alphagov/govuk-content-schemas/pull/410