### PR TITLE
Don’t use HTML5 browser ‘required’ validation

### DIFF
--- a/app/views/shared/_improve_this_page.html.erb
+++ b/app/views/shared/_improve_this_page.html.erb
@@ -21,7 +21,7 @@
           <div class="improve-this-page__section">
             <label>
               <span class="improve-this-page__label">How should we improve this page?</span><span class="visually-hidden">required</span>
-              <textarea name="description" rows="5" required></textarea>
+              <textarea name="description" rows="5"></textarea>
             </label>
           </div>
           <p>Include your name and email address if you'd like us to get back to you.</p>

--- a/app/views/shared/_improve_this_page.html.erb
+++ b/app/views/shared/_improve_this_page.html.erb
@@ -20,8 +20,8 @@
           <input type="hidden" name="user_agent" value="<%= request.user_agent -%>">
           <div class="improve-this-page__section">
             <label>
-              <span class="improve-this-page__label">How should we improve this page?</span><span class="visually-hidden">required</span>
-              <textarea name="description" rows="5"></textarea>
+              <span class="improve-this-page__label">How should we improve this page?</span>
+              <textarea name="description" rows="5" aria-required="true"></textarea>
             </label>
           </div>
           <p>Include your name and email address if you'd like us to get back to you.</p>


### PR DESCRIPTION
The HTML5 validation is provided by the browser and we are not able to style the error messages. This means that the validation experience is inconsistent with other parts of GOV.UK and with any more advanced validation that might happen server side.

There is already server side validation for the description being required, so the simplest fix is just to remove the required attribute and fall back to that.

https://trello.com/c/sIU9cdr1/464-consistent-validation-experience-with-improve-this-page-form