### PR TITLE
Bump govuk_frontend_toolkit to 5.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby File.read(".ruby-version").strip
 
 gem 'airbrake', '4.0'
-gem 'govuk_frontend_toolkit', '4.18.3'
+gem 'govuk_frontend_toolkit', '5.0.0'
 gem 'logstasher', '0.6.1'
 gem 'plek', '1.11'
 gem 'rails', '4.2.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     govuk-lint (0.6.1)
       rubocop (~> 0.35.0)
       scss_lint (~> 0.44.0)
-    govuk_frontend_toolkit (4.18.3)
+    govuk_frontend_toolkit (5.0.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     http-cookie (1.0.3)
@@ -274,7 +274,7 @@ DEPENDENCIES
   gds-api-adapters (= 27.0.0)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
-  govuk_frontend_toolkit (= 4.18.3)
+  govuk_frontend_toolkit (= 5.0.0)
   jasmine-rails
   logstasher (= 0.6.1)
   phantomjs (~> 1.9.7)


### PR DESCRIPTION
This release includes two breaking changes:

Removal of external link styles and icons, if you are using the
external-link-* mixins you will need to remove them from your codebase
(PR #293)

Correct spelling of the 'accordion' icon, you will need to check for
the incorrect spelling 'accordian' and update if you are using this
icon (PR #345)

And two minor changes:

Amend GOVUK.StickAtTopWhenScrolling to resize the sticky element and
shim when the .js-sticky-resize class is set (PR #343)

Allow custom options in GOVUK.analytics.trackPageview (#332)