### PR TITLE
Fix the improve-this-page prompt for smaller screens

### DIFF
--- a/app/assets/stylesheets/mixins/_helpers.scss
+++ b/app/assets/stylesheets/mixins/_helpers.scss
@@ -3,3 +3,8 @@
 @function em($px, $base: 19) {
   @return ($px / $base) + em;
 }
+
+// https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_shims.scss#L45
+.clearfix {
+  @extend %contain-floats;
+}

--- a/app/views/shared/_improve_this_page.html.erb
+++ b/app/views/shared/_improve_this_page.html.erb
@@ -1,5 +1,5 @@
 <div class="improve-this-page" data-module="improve-this-page">
-  <div class="js-prompt">
+  <div class="js-prompt clearfix">
     <h3 class="improve-this-page__is-useful-question">Is this page useful?</h3>
     <%= link_to contact_govuk_path, { class: 'button improve-this-page__page-is-useful-button js-page-is-useful', role: 'button' } do %>
       Yes <span class="visually-hidden"> this page is useful</span>


### PR DESCRIPTION
Before:

![before](https://cloud.githubusercontent.com/assets/417754/19696345/a5fe424e-9ade-11e6-8565-aafd4af65ddf.png)

After:

![fix](https://cloud.githubusercontent.com/assets/417754/19696347/aa3ece46-9ade-11e6-8a35-4fed93856fa9.png)

This PR fixes the prompt for feedback on the page, it's currently broken for smaller screens.
Clearing the parent wrapper (.js-prompt), fixes this.

Add a .clearfix helper class, use this to extend the contain-floats placeholder from the
govuk_frontend_toolkit.