### PR TITLE
Fix the alignment of page titles

### DIFF
--- a/app/assets/stylesheets/modules/_community-contact.scss
+++ b/app/assets/stylesheets/modules/_community-contact.scss
@@ -1,3 +1,7 @@
 .community-contact {
   @include gutter-vertical-margins;
+  @include media(tablet) {
+    text-align: right;
+    padding-top: $gutter-half;
+  }
 }

--- a/app/assets/stylesheets/modules/_page-header.scss
+++ b/app/assets/stylesheets/modules/_page-header.scss
@@ -20,6 +20,7 @@
     @include core-24;
 
     color: $secondary-text-colour;
+    margin-bottom: 0;
     padding-bottom: .167em;
   }
 


### PR DESCRIPTION
This fixes #54.

Reduce the spacing under the page context.

Get the "Give feedback on this page" link to line up.

Screenshot before:

![before](https://cloud.githubusercontent.com/assets/417754/19696874/e3db4bbe-9ae0-11e6-9570-16d216085617.png)

Screenshot after:

![after](https://cloud.githubusercontent.com/assets/417754/19696830/c405d912-9ae0-11e6-8d16-3eff680a36e3.png)
