### PR TITLE
'Improve this page' Google Analyitcs event tracking

### DIFF
--- a/app/views/shared/_improve_this_page.html.erb
+++ b/app/views/shared/_improve_this_page.html.erb
@@ -1,7 +1,11 @@
 <div class="improve-this-page" data-module="improve-this-page">
   <div class="js-prompt clearfix">
     <h3 class="improve-this-page__is-useful-question">Is this page useful?</h3>
-    <%= link_to contact_govuk_path, { class: 'button improve-this-page__page-is-useful-button js-page-is-useful', role: 'button' } do %>
+    <%= link_to contact_govuk_path, {
+          class: 'button improve-this-page__page-is-useful-button js-page-is-useful',
+          role: 'button',
+          data: { 'track-category' => 'manualFeedbackForm', 'track-action' => 'ffYesClick' },
+        } do %>
       Yes <span class="visually-hidden"> this page is useful</span>
     <% end %>
     <%= link_to contact_govuk_path, { class: 'button js-offer-feedback', role: 'button' } do %>
@@ -11,7 +15,7 @@
       Is there anything wrong with this page? <span class="visually-hidden"> this page is not useful</span>
     <% end %>
   </div>
-  <div class="js-feedback-form js-hidden">
+  <div class="js-feedback-form js-hidden" data-track-category="manualFeedbackForm" data-track-action="ffFormSubmit">
     <div class="grid-row">
       <div class="column-two-thirds">
         <div class="js-errors"></div>

--- a/app/views/shared/_improve_this_page.html.erb
+++ b/app/views/shared/_improve_this_page.html.erb
@@ -8,10 +8,18 @@
         } do %>
       Yes <span class="visually-hidden"> this page is useful</span>
     <% end %>
-    <%= link_to contact_govuk_path, { class: 'button js-offer-feedback', role: 'button' } do %>
+    <%= link_to contact_govuk_path, {
+          class: 'button js-page-is-not-useful',
+          role: 'button',
+          data: { 'track-category' => 'manualFeedbackForm', 'track-action' => 'ffNoClick' },
+        } do %>
       No <span class="visually-hidden"> this page is not useful</span>
     <% end %>
-    <%= link_to contact_govuk_path, { class: 'button js-offer-feedback improve-this-page__anything-wrong', role: 'button' } do %>
+    <%= link_to contact_govuk_path, {
+          class: 'button js-something-is-wrong improve-this-page__anything-wrong',
+          role: 'button',
+          data: { 'track-category' => 'manualFeedbackForm', 'track-action' => 'ffWrongClick' },
+        } do %>
       Is there anything wrong with this page? <span class="visually-hidden"> this page is not useful</span>
     <% end %>
   </div>

--- a/spec/javascripts/improve-this-page-spec.js
+++ b/spec/javascripts/improve-this-page-spec.js
@@ -4,9 +4,9 @@ describe("Improve this page", function () {
       '<div class="js-prompt">' +
         '<span class="improve-this-page__is-useful-question">Is this page useful?</span>' +
         '<a href="/contact/govuk" class="js-page-is-useful" data-track-category="improve-this-page" data-track-action="page-is-useful">Yes</a>' +
-        '<a href="/contact/govuk" class="js-offer-feedback">No</a>' +
+        '<a href="/contact/govuk" class="js-page-is-not-useful" data-track-category="improve-this-page" data-track-action="page-is-not-useful">No</a>' +
         '<div class="improve-this-page__anything-wrong">' +
-          '<a href="/contact/govuk" class="js-offer-feedback">Is there anything wrong with this page?</a>' +
+          '<a href="/contact/govuk" class="js-something-is-wrong" data-track-category="improve-this-page" data-track-action="something-is-wrong">Is there anything wrong with this page?</a>' +
         '</div>' +
       '</div>' +
       '<div class="js-feedback-form js-hidden" data-track-category="improve-this-page" data-track-action="give-feedback">' +
@@ -66,17 +66,65 @@ describe("Improve this page", function () {
     });
   });
 
-  describe("Offering to give feedback", function () {
+  describe("Saying the page was not useful", function () {
     it("shows the feedback form and hides the prompt", function () {
       loadImproveThisPage();
 
       expect($('.improve-this-page .js-prompt')).not.toHaveClass('js-hidden');
       expect($('.improve-this-page .js-feedback-form')).toHaveClass('js-hidden');
 
-      $('a.js-offer-feedback').click();
+      $('a.js-page-is-not-useful').click();
 
       expect($('.improve-this-page .js-prompt')).toHaveClass('js-hidden');
       expect($('.improve-this-page .js-feedback-form')).not.toHaveClass('js-hidden');
+    });
+
+    it("triggers a Google Analytics event", function () {
+      var analytics = {
+        trackEvent: function() {}
+      };
+
+      withGovukAnalytics(analytics, function () {
+        spyOn(GOVUK.analytics, 'trackEvent');
+
+        loadImproveThisPage();
+
+        $('a.js-page-is-not-useful').click();
+
+        expect(GOVUK.analytics.trackEvent).
+          toHaveBeenCalledWith('improve-this-page', 'page-is-not-useful');
+      });
+    });
+  });
+
+  describe("Saying there is something wrong with the page", function () {
+    it("shows the feedback form and hides the prompt", function () {
+      loadImproveThisPage();
+
+      expect($('.improve-this-page .js-prompt')).not.toHaveClass('js-hidden');
+      expect($('.improve-this-page .js-feedback-form')).toHaveClass('js-hidden');
+
+      $('a.js-something-is-wrong').click();
+
+      expect($('.improve-this-page .js-prompt')).toHaveClass('js-hidden');
+      expect($('.improve-this-page .js-feedback-form')).not.toHaveClass('js-hidden');
+    });
+
+    it("triggers a Google Analytics event", function () {
+      var analytics = {
+        trackEvent: function() {}
+      };
+
+      withGovukAnalytics(analytics, function () {
+        spyOn(GOVUK.analytics, 'trackEvent');
+
+        loadImproveThisPage();
+
+        $('a.js-something-is-wrong').click();
+
+        expect(GOVUK.analytics.trackEvent).
+          toHaveBeenCalledWith('improve-this-page', 'something-is-wrong');
+      });
     });
   });
 


### PR DESCRIPTION
We need to track what the user is clicking on so we can judge the new feedback form's effectiveness.

The original version of 'Improve this page' tracked the 'Yes' button and the submission of the feedback form. This additionally tracks the 'No' button and the 'Is there anything wrong with this page?' link.