### PR TITLE
SurveyMonkey custom variable

### DIFF
--- a/app/helpers/phase_label_helper.rb
+++ b/app/helpers/phase_label_helper.rb
@@ -6,4 +6,10 @@ module PhaseLabelHelper
       render partial: "govuk_component/#{presented_object.phase}_label", locals: locals
     end
   end
+
+  def surveymonkey_url
+    url = "https://www.surveymonkey.co.uk/r/servicemanualsurvey"
+    url += "?c=#{request.path}" if request.path.present?
+    url
+  end
 end

--- a/app/views/shared/_service_manual_custom_phase_message.html.erb
+++ b/app/views/shared/_service_manual_custom_phase_message.html.erb
@@ -1,1 +1,1 @@
-This is new guidance. Complete our quick 5-question survey to <%= link_to "help us improve it", "https://www.surveymonkey.co.uk/r/servicemanualsurvey" %>.
+This is new guidance. Complete our quick 5-question survey to <%= link_to "help us improve it", surveymonkey_url %>.

--- a/test/helpers/phase_label_helper_test.rb
+++ b/test/helpers/phase_label_helper_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class PhaseLabelHelperTest < ActionView::TestCase
+  test "#surveymonkey_url includes a custom variable" do
+    stub(:request, ActionController::TestRequest.new('PATH_INFO' => '/service-manual/agile')) do
+      assert_equal "https://www.surveymonkey.co.uk/r/servicemanualsurvey?c=/service-manual/agile", surveymonkey_url
+    end
+  end
+
+  test "#surveymonkey_url does not include a custom variable if the request path is nil" do
+    stub(:request, ActionController::TestRequest.new) do
+      assert_equal "https://www.surveymonkey.co.uk/r/servicemanualsurvey", surveymonkey_url
+    end
+  end
+end

--- a/test/integration/phase_label_test.rb
+++ b/test/integration/phase_label_test.rb
@@ -19,7 +19,7 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
 
     visit "/service-manual/agile"
     assert_has_phase_label phase
-    expected_phase_message = %{This is new guidance. Complete our quick 5-question survey to <a href="https://www.surveymonkey.co.uk/r/servicemanualsurvey">help us improve it</a>.}
+    expected_phase_message = %{This is new guidance. Complete our quick 5-question survey to <a href="https://www.surveymonkey.co.uk/r/servicemanualsurvey?c=/service-manual/agile">help us improve it</a>.}
     assert_has_phase_label_message phase, expected_phase_message
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'minitest/mock'
 require 'webmock/minitest'
 require 'capybara/rails'
 require 'capybara/poltergeist'


### PR DESCRIPTION
The phase label has a link to fill out a surveymonkey survey. If we add a custom variable with the request path then it'll be possible to see which page the user came from in the surveymonkey analytics.

https://trello.com/c/d8dDWj2i/492-update-survey-monkey-code-on-service-manual-to-return-url-slug-as-custom-dimension