### PR TITLE
Use capybara's auto waiting for Improve this page

### DIFF
--- a/test/integration/improve_this_page_test.rb
+++ b/test/integration/improve_this_page_test.rb
@@ -36,6 +36,6 @@ class ImproveThisPageTest < ActionDispatch::IntegrationTest
   # of the class rather than rely on PhantomJS to know whether the element is visible
   # or not.
   def feedback_form_is_hidden
-    page.find('.js-feedback-form')[:class].include?('js-hidden')
+    page.has_css?(%{.js-feedback-form[class*="js-hidden"]})
   end
 end


### PR DESCRIPTION
Capybara's `#find` does wait, but only for the selector it's provided with. Any chained expectations will not wait. This changes the expectation so we can get rid of the chained stuff.

This is an attempted fix for the intermittent failure on CI.

Here is an example broken build: https://ci.dev.publishing.service.gov.uk/job/govuk_service_manual_frontend_branches/386/console