### PR TITLE
Upgrade gds-api-adapters to 37.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'rails_translation_manager', '~> 0.0.2'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '27.0.0'
+  gem 'gds-api-adapters', '~> 37.5'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,17 +70,17 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
-    domain_name (0.5.20160826)
+    domain_name (0.5.20161021)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    gds-api-adapters (27.0.0)
+    gds-api-adapters (37.5.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     govuk-content-schema-test-helpers (1.1.0)
@@ -118,7 +118,9 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (2.99.3)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.0.0)
     minitest (5.9.1)
     multi_json (1.11.2)
@@ -144,7 +146,7 @@ GEM
     pry-byebug (3.3.0)
       byebug (~> 8.0)
       pry (~> 0.10)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
@@ -183,10 +185,10 @@ GEM
     raindrops (0.15.0)
     rake (10.5.0)
     request_store (1.3.0)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     robotex (1.0.0)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
@@ -271,7 +273,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
-  gds-api-adapters (= 27.0.0)
+  gds-api-adapters (~> 37.5)
   govuk-content-schema-test-helpers (= 1.1.0)
   govuk-lint
   govuk_frontend_toolkit (= 5.0.0)

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -34,8 +34,13 @@ class ContentItemsController < ApplicationController
 private
 
   def load_content_item
-    content_item = content_store.content_item(content_item_path)
-    @content_item = present(content_item) if content_item
+    begin
+      @content_item = present(
+        content_store.content_item(content_item_path)
+      )
+    rescue GdsApi::HTTPNotFound
+      nil
+    end
   end
 
   def present(content_item)

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 require 'slimmer/test_helpers/shared_templates'
 
 class ContentItemsControllerTest < ActionController::TestCase
-  include GdsApi::TestHelpers::ContentStore
   include Slimmer::TestHelpers::SharedTemplates
 
   test "routing handles translated content paths" do
@@ -60,7 +59,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   test "returns 403 for access-limited item" do
     path = 'government/case-studies/super-sekrit-document'
-    url = CONTENT_STORE_ENDPOINT + "/content/" + path
+    url = content_store_endpoint + "/content/" + path
     stub_request(:get, url).to_return(status: 403, headers: {})
 
     get :show, path: path


### PR DESCRIPTION
These days the default behaviour of the gds-api-adapters is to raise a GdsApi::HTTPNotFound if the resource can't be found.

I started out just trying to get rid of the warnings in the test output and realised how far behind gds-api-adapters was, which is where the warning was coming from. Looking at the gds-api-adapters changelog, I don't think it's worth pinning to exact patch versions. It doesn't change that dramatically. This changes the pin to stop it sneakily upgrading to the next major version, but minor and patches are 👌.

https://github.com/alphagov/gds-api-adapters/blob/master/CHANGELOG.md