### PR TITLE
Add anchors to section headings, automatically expand linked to sections

### DIFF
--- a/app/assets/javascripts/govuk/current_location.js
+++ b/app/assets/javascripts/govuk/current_location.js
@@ -1,0 +1,8 @@
+(function(root) {
+  "use strict";
+  root.GOVUK = root.GOVUK || {};
+
+  root.GOVUK.getCurrentLocation = function(){
+    return root.location;
+  };
+}(window));

--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -25,6 +25,7 @@
 
       closeOpenSections();
       checkSessionStorage();
+      openLinkedSection();
 
       bindToggleForSubsections();
       bindToggleOpenCloseAllButton();
@@ -36,7 +37,6 @@
       function replaceSpacesWithUnderscores(str) {
         return str.replace(/\s+/g,"_");
       }
-
 
       function serviceManualTopicPrefix() {
         var topic = getserviceManualTopic();
@@ -79,6 +79,27 @@
       function closeOpenSections() {
         var $subsectionContent = $element.find('.subsection__content');
         closeSection($subsectionContent);
+      }
+
+      function openLinkedSection() {
+        var anchor = getActiveAnchor(),
+            section;
+
+        if (!anchor.length) {
+          return;
+        }
+
+        section = $element.find(anchor)
+          .parents('.subsection')
+          .find('.subsection__content');
+
+        if (section.length) {
+          openSection(section);
+        }
+      }
+
+      function getActiveAnchor() {
+        return GOVUK.getCurrentLocation().hash;
       }
 
       function checkSessionStorage() {

--- a/app/views/content_items/service_manual_topic.html.erb
+++ b/app/views/content_items/service_manual_topic.html.erb
@@ -27,7 +27,7 @@
             <div class="subsection">
             <% if link_group.name.present? %>
               <div class="subsection__header">
-                <h2 class="subsection__title"><%= link_group.name %></h2>
+                <h2 class="subsection__title" id="<%= link_group.name.parameterize %>"><%= link_group.name %></h2>
               <% if link_group.description.present? %>
                 <p class="subsection__description"><%= link_group.description %></p>
               <% end %>

--- a/spec/javascripts/accordion-with-descriptions-spec.js
+++ b/spec/javascripts/accordion-with-descriptions-spec.js
@@ -2,215 +2,242 @@ describe('An accordion with descriptions module', function () {
   "use strict";
 
   var $element;
-
-  beforeEach(function() {
-    $element = $('<div class="subsections js-hidden" data-module="accordion-with-descriptions">\
-        <div class="subsection-wrapper">\
-          <div class="subsection">\
-            <div class="subsection__header">\
-              <h2 class="subsection__title">Subsection title in here</h2>\
-              <p class="subsection__description">Subsection description in here</p>\
-            </div>\
-            <div class="subsection__content" id="subsection_content_0">\
-              <ul class="subsection__list">\
-                <li class="subsection__list-item">\
-                  <a href="">Subsection list item in here</a>\
-                </li>\
-              </ul>\
-            </div>\
+  var html = '\
+    <div class="subsections js-hidden" data-module="accordion-with-descriptions">\
+      <div class="subsection-wrapper">\
+        <div class="subsection">\
+          <div class="subsection__header">\
+            <h2 class="subsection__title" id="topic-section-one">Topic Section One</h2>\
+            <p class="subsection__description">Subsection description in here</p>\
           </div>\
-          <div class="subsection">\
-            <div class="subsection__header">\
-              <h2 class="subsection__title">Subsection title in here</h2>\
-              <p class="subsection__description">Subsection description in here</p>\
-            </div>\
-            <div class="subsection__content" id="subsection_content_1">\
-              <ul class="subsection__list">\
-                <li class="subsection__list-item">\
-                  <a href="">Subsection list item in here</a>\
-                </li>\
-              </ul>\
-            </div>\
+          <div class="subsection__content" id="subsection_content_0">\
+            <ul class="subsection__list">\
+              <li class="subsection__list-item">\
+                <a href="">Subsection list item in here</a>\
+              </li>\
+            </ul>\
           </div>\
         </div>\
-      </div>');
-
-    var accordion = new GOVUK.Modules.AccordionWithDescriptions();
-    accordion.start($element);
-  });
+        <div class="subsection">\
+          <div class="subsection__header">\
+            <h2 class="subsection__title" id="topic-section-two">Topic Section Two</h2>\
+            <p class="subsection__description">Subsection description in here</p>\
+          </div>\
+          <div class="subsection__content" id="subsection_content_1">\
+            <ul class="subsection__list">\
+              <li class="subsection__list-item">\
+                <a href="">Subsection list item in here</a>\
+              </li>\
+            </ul>\
+          </div>\
+        </div>\
+      </div>\
+    </div>';
 
   afterEach(function() {
     $(document).off();
   });
 
-  // Setup
-
-  // Add & remove classes to show the JS has worked
-
-  // Add a class .js-accordion-with-descriptions
-  it("has a class of js-accordion-with-descriptions", function () {
-    expect($element).toHaveClass("js-accordion-with-descriptions");
-  });
-
-  // Remove the class .js-hidden
-  it("does not have a class of js-hidden", function () {
-    expect($element).not.toHaveClass("js-hidden");
-  });
-
-  // Add a subsection controls div, with a class of .js-subsection controls
-  it("has a child element with a class of subsection-controls", function () {
-    expect($element).toContainElement('.js-subsection-controls');
-  });
-
-  // Add an 'Open all' button
-
-  // Insert a button inside .js-subsection-controls
-  it("has a child element which is a button", function () {
-    expect($element).toContainElement('.js-subsection-controls button');
-  });
-
-  // Set the correct text 'Open all' and aria attributes (aria-expanded, aria-controls) for the button
-  it("has an open/close all button with text inside which is equal to Open all", function () {
-    var $openCloseAllButton = $element.find('.js-subsection-controls button');
-
-    expect($openCloseAllButton).toHaveText("Open all");
-  });
-
-  // Set the correct text and aria attributes (aria-expanded, aria-controls) for the button
-
-  it("has an open/close all button with an aria-expanded attribute and it is false (as all subsections are initially closed)", function () {
-    var $button = $element.find('.js-subsection-controls button');
-
-    expect($button).toHaveAttr("aria-expanded", "false");
-  });
-
-  it("has an open/close all button, with a value for the aria-controls attribute that includes all of the subsection_content_IDs", function () {
-    var $openCloseAllButton = $element.find('.js-subsection-controls button');
-
-    expect($openCloseAllButton).toHaveAttr('aria-controls','subsection_content_0 subsection_content_1 ');
-  });
-
-  // Setup the open/close functionality for each section
-
-  // Insert a button into each subsection heading
-  // Set the correct text and aria attributes (aria-expanded, aria-controls) for the button
-  it("has a section with a heading with a class of .subsection__title and a child element which is a button", function () {
-    var $subsectionButton = $element.find('.subsection__title button:first');
-
-    expect($subsectionButton).toHaveClass('subsection__button');
-    expect($subsectionButton).toHaveAttr('aria-expanded','false');
-    expect($subsectionButton).toHaveAttr('aria-controls','subsection_content_0');
-  });
-
-  // Ensure the wrapper for the list of links is initially hidden
-  it("has two subsection-content items (one for each section) which are initially hidden", function () {
-    var $subsectionContent = $element.find('.subsection__content');
-
-    expect($subsectionContent).toHaveLength(2);
-    expect($subsectionContent).toHaveClass('js-hidden');
-  });
-
-  // Ensure that the subsection-icon div has been inserted
-  it("has a header with a child element which has a class of .subsection-icon", function () {
-    var $subsectionHeader = $element.find('.subsection__header');
-
-    expect($subsectionHeader).toContainElement('.subsection__icon');
-  });
-
-  describe('When the open/close all button is clicked', function () {
-
-    // Before the open/close all button is clicked
-    it("has no subsections which have an open state, the button text should be 'Open all'", function () {
-      var $openCloseAllButton = $element.find('.js-subsection-controls button');
-      var openSubsections = $element.find('.subsection--is-open').length;
-
-      // When all sections are closed, make sure there are no --is-open classes
-      expect(openSubsections).toEqual(0);
-      expect($openCloseAllButton).toContainText("Open all");
+  describe('when no sub section is linked to', function () {
+    beforeEach(function() {
+      var accordion = new GOVUK.Modules.AccordionWithDescriptions();
+      $element = $(html);
+      accordion.start($element);
     });
 
-    // Check that the total number of is-open classes matches the number of sections (so all are opened)
-    it("has two subsections which have an open state (this is equal to the total number of sections), the button text should be Close all", function () {
-      var $openCloseAllButton = $element.find('.js-subsection-controls button');
-      var openSubsections = $element.find('.subsection--is-open').length;
+    // Setup
 
-      $openCloseAllButton.click();
+    // Add & remove classes to show the JS has worked
 
-      var openSubsections = $element.find('.subsection--is-open').length;
-      expect(openSubsections).toEqual(2);
-      expect($openCloseAllButton).toContainText("Close all");
-
-      var totalSubsections = $element.find('.subsection__content').length;
-      expect(totalSubsections).toEqual(openSubsections);
+    // Add a class .js-accordion-with-descriptions
+    it("has a class of js-accordion-with-descriptions", function () {
+      expect($element).toHaveClass("js-accordion-with-descriptions");
     });
 
-  });
-
-  describe('When a section is open', function () {
-
-    // When a section is open (testing: toggleSection, openSection)
+    // Remove the class .js-hidden
     it("does not have a class of js-hidden", function () {
-      var $subsectionButton = $element.find('.subsection__title button:first');
-      var $subsectionContent = $element.find('.subsection__content:first');
-      $subsectionButton.click();
-      expect($subsectionContent).not.toHaveClass("js-hidden");
+      expect($element).not.toHaveClass("js-hidden");
     });
 
-    // When a section is open (testing: toggleState, setExpandedState)
-    it("has a an aria-expanded attribute and the value is true", function () {
-      var $subsectionButton = $element.find('.subsection__title button:first');
-      $subsectionButton.click();
-      expect($subsectionButton).toHaveAttr('aria-expanded','true');
+    // Add a subsection controls div, with a class of .js-subsection controls
+    it("has a child element with a class of subsection-controls", function () {
+      expect($element).toContainElement('.js-subsection-controls');
     });
 
-    it("has its state saved in session storage", function () {
-      var GOVUKServiceManualTopic = "GOVUK_service_manual_agile_delivery";
+    // Add an 'Open all' button
 
-      var $subsectionButton = $element.find('.subsection__title button');
-      $subsectionButton.click();
-
-      var $openSubsections = $('.subsection--is-open');
-      var subsectionOpenContentId = $openSubsections.find('.subsection__content').attr('id');
-      sessionStorage.setItem(GOVUKServiceManualTopic+subsectionOpenContentId , 'Opened');
-
-      var storedItem = sessionStorage.getItem(GOVUKServiceManualTopic+subsectionOpenContentId);
-      expect(storedItem).toEqual('Opened');
+    // Insert a button inside .js-subsection-controls
+    it("has a child element which is a button", function () {
+      expect($element).toContainElement('.js-subsection-controls button');
     });
 
-  });
+    // Set the correct text 'Open all' and aria attributes (aria-expanded, aria-controls) for the button
+    it("has an open/close all button with text inside which is equal to Open all", function () {
+      var $openCloseAllButton = $element.find('.js-subsection-controls button');
 
-  describe('When a section is closed', function () {
-
-    // When a section is closed (testing: toggleSection, closeSection)
-    it("has a class of js-hidden", function () {
-      var $subsectionButton = $element.find('.subsection__title button:first');
-      var $subsectionContent = $element.find('.subsection__content:first');
-      $subsectionButton.click();
-      expect($subsectionContent).not.toHaveClass("js-hidden");
-      $subsectionButton.click();
-      expect($subsectionContent).toHaveClass("js-hidden");
+      expect($openCloseAllButton).toHaveText("Open all");
     });
 
-    // When a section is closed (testing: toggleState, setExpandedState)
-    it("has a an aria-expanded attribute and the value is false", function () {
+    // Set the correct text and aria attributes (aria-expanded, aria-controls) for the button
+
+    it("has an open/close all button with an aria-expanded attribute and it is false (as all subsections are initially closed)", function () {
+      var $button = $element.find('.js-subsection-controls button');
+
+      expect($button).toHaveAttr("aria-expanded", "false");
+    });
+
+    it("has an open/close all button, with a value for the aria-controls attribute that includes all of the subsection_content_IDs", function () {
+      var $openCloseAllButton = $element.find('.js-subsection-controls button');
+
+      expect($openCloseAllButton).toHaveAttr('aria-controls','subsection_content_0 subsection_content_1 ');
+    });
+
+    // Setup the open/close functionality for each section
+
+    // Insert a button into each subsection heading
+    // Set the correct text and aria attributes (aria-expanded, aria-controls) for the button
+    it("has a section with a heading with a class of .subsection__title and a child element which is a button", function () {
       var $subsectionButton = $element.find('.subsection__title button:first');
-      var $subsectionContent = $element.find('.subsection__content');
-      $subsectionButton.click();
-      expect($subsectionButton).toHaveAttr('aria-expanded','true');
-      $subsectionButton.click();
+
+      expect($subsectionButton).toHaveClass('subsection__button');
       expect($subsectionButton).toHaveAttr('aria-expanded','false');
+      expect($subsectionButton).toHaveAttr('aria-controls','subsection_content_0');
     });
 
-    it("has its state removed in session storage", function () {
-      var GOVUKServiceManualTopic = "GOVUK_service_manual_agile_delivery";
+    // Ensure the wrapper for the list of links is initially hidden
+    it("has two subsection-content items (one for each section) which are initially hidden", function () {
+      var $subsectionContent = $element.find('.subsection__content');
 
-      var $closedSubsections = $element.find('.subsection');
-      var subsectionClosedContentId = $closedSubsections.find('.subsection__content').attr('id');
-      sessionStorage.removeItem(GOVUKServiceManualTopic+subsectionClosedContentId , 'Opened');
-      var removedItem = sessionStorage.getItem(GOVUKServiceManualTopic+subsectionClosedContentId);
-      expect(removedItem).not.toExist();
+      expect($subsectionContent).toHaveLength(2);
+      expect($subsectionContent).toHaveClass('js-hidden');
     });
 
+    // Ensure that the subsection-icon div has been inserted
+    it("has a header with a child element which has a class of .subsection-icon", function () {
+      var $subsectionHeader = $element.find('.subsection__header');
+
+      expect($subsectionHeader).toContainElement('.subsection__icon');
+    });
+
+    describe('When the open/close all button is clicked', function () {
+
+      // Before the open/close all button is clicked
+      it("has no subsections which have an open state, the button text should be 'Open all'", function () {
+        var $openCloseAllButton = $element.find('.js-subsection-controls button');
+        var openSubsections = $element.find('.subsection--is-open').length;
+
+        // When all sections are closed, make sure there are no --is-open classes
+        expect(openSubsections).toEqual(0);
+        expect($openCloseAllButton).toContainText("Open all");
+      });
+
+      // Check that the total number of is-open classes matches the number of sections (so all are opened)
+      it("has two subsections which have an open state (this is equal to the total number of sections), the button text should be Close all", function () {
+        var $openCloseAllButton = $element.find('.js-subsection-controls button');
+        var openSubsections = $element.find('.subsection--is-open').length;
+
+        $openCloseAllButton.click();
+
+        var openSubsections = $element.find('.subsection--is-open').length;
+        expect(openSubsections).toEqual(2);
+        expect($openCloseAllButton).toContainText("Close all");
+
+        var totalSubsections = $element.find('.subsection__content').length;
+        expect(totalSubsections).toEqual(openSubsections);
+      });
+
+    });
+
+    describe('When a section is open', function () {
+
+      // When a section is open (testing: toggleSection, openSection)
+      it("does not have a class of js-hidden", function () {
+        var $subsectionButton = $element.find('.subsection__title button:first');
+        var $subsectionContent = $element.find('.subsection__content:first');
+        $subsectionButton.click();
+        expect($subsectionContent).not.toHaveClass("js-hidden");
+      });
+
+      // When a section is open (testing: toggleState, setExpandedState)
+      it("has a an aria-expanded attribute and the value is true", function () {
+        var $subsectionButton = $element.find('.subsection__title button:first');
+        $subsectionButton.click();
+        expect($subsectionButton).toHaveAttr('aria-expanded','true');
+      });
+
+      it("has its state saved in session storage", function () {
+        var GOVUKServiceManualTopic = "GOVUK_service_manual_agile_delivery";
+
+        var $subsectionButton = $element.find('.subsection__title button');
+        $subsectionButton.click();
+
+        var $openSubsections = $('.subsection--is-open');
+        var subsectionOpenContentId = $openSubsections.find('.subsection__content').attr('id');
+        sessionStorage.setItem(GOVUKServiceManualTopic+subsectionOpenContentId , 'Opened');
+
+        var storedItem = sessionStorage.getItem(GOVUKServiceManualTopic+subsectionOpenContentId);
+        expect(storedItem).toEqual('Opened');
+      });
+
+    });
+
+    describe('When a section is closed', function () {
+
+      // When a section is closed (testing: toggleSection, closeSection)
+      it("has a class of js-hidden", function () {
+        var $subsectionButton = $element.find('.subsection__title button:first');
+        var $subsectionContent = $element.find('.subsection__content:first');
+        $subsectionButton.click();
+        expect($subsectionContent).not.toHaveClass("js-hidden");
+        $subsectionButton.click();
+        expect($subsectionContent).toHaveClass("js-hidden");
+      });
+
+      // When a section is closed (testing: toggleState, setExpandedState)
+      it("has a an aria-expanded attribute and the value is false", function () {
+        var $subsectionButton = $element.find('.subsection__title button:first');
+        var $subsectionContent = $element.find('.subsection__content');
+        $subsectionButton.click();
+        expect($subsectionButton).toHaveAttr('aria-expanded','true');
+        $subsectionButton.click();
+        expect($subsectionButton).toHaveAttr('aria-expanded','false');
+      });
+
+      it("has its state removed in session storage", function () {
+        var GOVUKServiceManualTopic = "GOVUK_service_manual_agile_delivery";
+
+        var $closedSubsections = $element.find('.subsection');
+        var subsectionClosedContentId = $closedSubsections.find('.subsection__content').attr('id');
+        sessionStorage.removeItem(GOVUKServiceManualTopic+subsectionClosedContentId , 'Opened');
+        var removedItem = sessionStorage.getItem(GOVUKServiceManualTopic+subsectionClosedContentId);
+        expect(removedItem).not.toExist();
+      });
+
+    });
   });
 
+  describe('When linking to a topic section', function () {
+    beforeEach(function() {
+      var accordion = new GOVUK.Modules.AccordionWithDescriptions();
+      $element = $(html);
+      spyOn(GOVUK, 'getCurrentLocation').and.returnValue({
+        hash: '#topic-section-one'
+      });
+      accordion.start($element);
+    });
+
+    it("opens the linked to topic section", function () {
+      var $subsectionContent = $element.find('#topic-section-one')
+        .parents('.subsection').find('.subsection__content');
+
+      expect($subsectionContent).not.toHaveClass('js-hidden');
+    });
+
+    it("leaves other sections closed", function () {
+      var $subsectionContent = $element.find('#topic-section-two')
+        .parents('.subsection').find('.subsection__content');
+
+      expect($subsectionContent).toHaveClass('js-hidden');
+    });
+  });
 });

--- a/test/integration/service_manual_topic_test.rb
+++ b/test/integration/service_manual_topic_test.rb
@@ -47,6 +47,14 @@ class ServiceManualTopicTest < ActionDispatch::IntegrationTest
       href: "/service-manual/test-expanded-topic/email-signup")
   end
 
+  test "it includes anchors for headings" do
+    using_javascript_driver do
+      setup_and_visit_example('service_manual_topic', 'service_manual_topic_collapsed')
+
+      assert page.has_css?("h2#group-1")
+    end
+  end
+
   test "it does not insert the accordion buttons if the topic isn't visually collapsed" do
     using_javascript_driver do
       setup_and_visit_example('service_manual_topic', 'service_manual_topic')


### PR DESCRIPTION
Allow linking directly to a topic section by adding anchors to all section headings, and modify the accordion Javascript to automatically expand any linked-to section.

The primary use for this is when redirecting from pages in the old manual, which best correspond to a topic section. We don't just want to redirect users to the topic as it may not be obvious why it relates to what they were originally trying to view.