### PR TITLE
Remove search on homepage (re-opened PR)

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -6,27 +6,20 @@ class ContentItemsController < ApplicationController
   rescue_from GdsApi::HTTPForbidden, with: :error_403
 
   def show
-    # The Slimmer middleware is responsible for intercepting the response and inserting the navigation header into the HTML body. We need to set the request headers here for the search form in the header to have the correct hidden input to scope the search results to just the service manual.
-
-    # It should look something like:
-
-    # <form id="search" class="site-search" action="/search" method="get" role="search">
-    #   <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
-    #   <input class="submit" type="submit" value="Search">
-    #   <input type="hidden" name="filter_manual" value="/service-manual">
-    # </form>
+    # The Slimmer middleware is responsible for intercepting the response and
+    # wrapping it with the GOV.UK header and footer. We want to use our own
+    # 'report a problem' pattern, so opt out of the bundled one.
     set_slimmer_headers(
-      search_parameters: {
-        "filter_manual" => "/service-manual"
-      }.to_json,
       report_a_problem: "false"
     )
 
     if load_content_item
       set_expiry
       set_locale
+      configure_header_search
       render content_item_template
     else
+      configure_header_search
       render text: 'Not found', status: :not_found
     end
   end
@@ -71,6 +64,30 @@ private
 
   def content_store
     @content_store ||= GdsApi::ContentStore.new(Plek.current.find("content-store"))
+  end
+
+  def configure_header_search
+    if @content_item.present? && @content_item.is_homepage?
+      remove_header_search
+    else
+      scope_header_search_to_service_manual
+    end
+  end
+
+  def scope_header_search_to_service_manual
+    # Slimmer is middleware which wraps the service manual in the GOV.UK header
+    # and footer. We set a response header so that Slimmer adds a hidden field
+    # to the header search to scope the search results to just the service
+    # manual.
+    set_slimmer_headers(
+      search_parameters: {
+        "filter_manual" => "/service-manual"
+      }.to_json,
+    )
+  end
+
+  def remove_header_search
+    set_slimmer_headers(remove_search: true)
   end
 
 private

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -90,8 +90,6 @@ private
     set_slimmer_headers(remove_search: true)
   end
 
-private
-
   def error_403(exception)
     render text: exception.message, status: 403
   end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -14,6 +14,10 @@ class ContentItemPresenter
     sorted_locales(@content_item["links"]["available_translations"])
   end
 
+  def is_homepage?
+    false
+  end
+
 private
 
   def display_time(timestamp)

--- a/app/presenters/service_manual_homepage_presenter.rb
+++ b/app/presenters/service_manual_homepage_presenter.rb
@@ -2,4 +2,8 @@ class ServiceManualHomepagePresenter < ContentItemPresenter
   def breadcrumbs
     []
   end
+
+  def is_homepage?
+    true
+  end
 end

--- a/app/presenters/service_manual_topic_presenter.rb
+++ b/app/presenters/service_manual_topic_presenter.rb
@@ -1,14 +1,8 @@
-class ServiceManualTopicPresenter
+class ServiceManualTopicPresenter < ContentItemPresenter
   ContentOwner = Struct.new(:title, :href)
-  attr_reader :content_item, :title, :format, :description, :locale
 
   def initialize(content_item)
-    @content_item = content_item
-
-    @title = content_item["title"]
-    @description = content_item["description"]
-    @format = content_item["format"]
-    @locale = content_item["locale"]
+    super
     @visually_collapsed = content_item["details"]["visually_collapsed"]
   end
 
@@ -41,10 +35,6 @@ class ServiceManualTopicPresenter
 
   def visually_collapsed?
     @visually_collapsed
-  end
-
-  def is_homepage?
-    false
   end
 
 private

--- a/app/presenters/service_manual_topic_presenter.rb
+++ b/app/presenters/service_manual_topic_presenter.rb
@@ -43,6 +43,10 @@ class ServiceManualTopicPresenter
     @visually_collapsed
   end
 
+  def is_homepage?
+    false
+  end
+
 private
 
   def topic_breadcrumb

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -83,6 +83,16 @@ class ContentItemsControllerTest < ActionController::TestCase
       'the header is not set correctly'
   end
 
+  test 'guides should tell slimmer to scope search results to the manual' do
+    content_item = content_store_has_schema_example('service_manual_guide', 'service_manual_guide')
+
+    get :show, path: path_for(content_item)
+    assert_equal(
+      { filter_manual: "/service-manual" }.to_json,
+      @response.headers[Slimmer::Headers::SEARCH_PARAMETERS_HEADER]
+    )
+  end
+
   def path_for(content_item)
     content_item['base_path'].sub(/^\//, '')
   end

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -93,6 +93,13 @@ class ContentItemsControllerTest < ActionController::TestCase
     )
   end
 
+  test 'the homepage should tell slimmer not to include a search box in the header' do
+    content_item = content_store_has_schema_example('service_manual_homepage', 'service_manual_homepage')
+
+    get :show, path: path_for(content_item)
+    assert_equal 'true', @response.headers[Slimmer::Headers::REMOVE_SEARCH_HEADER]
+  end
+
   def path_for(content_item)
     content_item['base_path'].sub(/^\//, '')
   end


### PR DESCRIPTION
This is a revision of PR #56 but targeting master.

We originally merged these homepage-related PRs into a feature branch (`homepage`) and then rebased that branch against master, but it lead to a really weird commit history so we've abandoned that.

So doing this again, but rebasing each branch in turn and targeting master directly.