### PR TITLE
Add homepage links to the standard and communities (re-opened PR)

### DIFF
--- a/app/assets/stylesheets/modules/_panel.scss
+++ b/app/assets/stylesheets/modules/_panel.scss
@@ -1,0 +1,19 @@
+.panel {
+  margin-top: $gutter-half;
+  padding-top: $gutter-half;
+
+  border-top: 1px solid $grey-2;
+
+  @include media(desktop) {
+    margin-top: $gutter;
+  }
+
+  &__title {
+    @include bold-24;
+    margin-bottom: $gutter-half;
+  }
+
+  &__description {
+    @include core-19;
+  }
+}

--- a/app/assets/stylesheets/screen.scss
+++ b/app/assets/stylesheets/screen.scss
@@ -15,6 +15,7 @@
 @import "modules/improve-this-page";
 @import "modules/page-contents";
 @import "modules/page-header";
+@import "modules/panel";
 @import "modules/related-content";
 @import "modules/search";
 @import "modules/service-standard-point";

--- a/app/views/content_items/service_manual_homepage.html.erb
+++ b/app/views/content_items/service_manual_homepage.html.erb
@@ -39,3 +39,19 @@
   <% end %>
   </div>
 <% end %>
+
+<div class="grid-row">
+  <div class="column-half">
+    <div class="panel">
+      <h2 class="panel__title">The Digital Service Standard</h2>
+      <p class="panel__description">The <%= link_to 'Digital Service Standard', '/service-manual/service-standard' %> provides the principles of building a good digital service. This manual explains what teams can do to build great digital services that will meet the standard.</p>
+    </div>
+  </div>
+
+  <div class="column-half">
+    <div class="panel">
+      <h2 class="panel__title">Communities of practice</h2>
+      <p class="panel__description">You can view the <%= link_to 'communities of practice', '/service-manual/communities' %> to find more learning resources, see who has written the guidance in the manual and connect with digital people like you from across government.</p>
+    </div>
+  </div>
+</div>

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -26,4 +26,28 @@ class HomepageTest < ActionDispatch::IntegrationTest
     assert page.has_content? "Agile delivery How to work in an agile way: principles, tools and governance."
     assert page.has_link? 'Agile delivery', href: '/service-manual/agile-delivery'
   end
+
+  test 'the homepage includes a link to the digital service standard' do
+    setup_and_visit_example('service_manual_homepage', 'service_manual_homepage')
+
+    assert page.has_content? <<-TEXT
+      The Digital Service Standard provides the principles of building a good
+      digital service. This manual explains what teams can do to build great
+      digital services that will meet the standard.
+    TEXT
+
+    assert page.has_link? 'Digital Service Standard', href: '/service-manual/service-standard'
+  end
+
+  test 'the homepage includes a link to the communities of practise' do
+    setup_and_visit_example('service_manual_homepage', 'service_manual_homepage')
+
+    assert page.has_content? <<-TEXT
+      You can view the communities of practice to find more learning
+      resources, see who has written the guidance in the manual and connect
+      with digital people like you from across government.
+    TEXT
+
+    assert page.has_link? 'communities of practice', href: '/service-manual/communities'
+  end
 end


### PR DESCRIPTION
This is a revision of PR #63 but targeting master.

We originally merged these homepage-related PRs into a feature branch (`homepage`) and then rebased that branch against master, but it lead to a really weird commit history so we've abandoned that.

So doing this again, but rebasing each branch in turn and targeting master directly.