### PR TITLE
Make the contact link more explicit and obvious

### DIFF
--- a/app/assets/stylesheets/modules/_hero.scss
+++ b/app/assets/stylesheets/modules/_hero.scss
@@ -33,11 +33,10 @@
   a:visited {
     font-weight: bold;
     color: $white;
-    text-decoration: none;
   }
 
-  a:active,
-  a:hover {
-    text-decoration: underline;
+  a:hover,
+  a:active {
+    color: $light-blue-25;
   }
 }

--- a/app/views/content_items/service_manual_homepage.html.erb
+++ b/app/views/content_items/service_manual_homepage.html.erb
@@ -25,7 +25,7 @@
     </div>
 
     <div class="column-one-third">
-      <p class="hero__feedback-link">Contact the <%= link_to 'Service Manual team', '/contact/govuk' %> with any comments or questions.</p>
+      <p class="hero__feedback-link"><%= link_to 'Contact the Service Manual team', '/contact/govuk' %> with any comments or questions.</p>
     </div>
   </div>
 </header>

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -17,7 +17,7 @@ class HomepageTest < ActionDispatch::IntegrationTest
       "Contact the Service Manual team with any comments or questions."
     )
 
-    assert page.has_link? 'Service Manual team', href: '/contact/govuk'
+    assert page.has_link? 'Contact the Service Manual team', href: '/contact/govuk'
   end
 
   test 'the homepage includes the titles and descriptions of associated topics' do


### PR DESCRIPTION
See individual commits for details

## Before
![screen shot 2016-12-19 at 17 04 54](https://cloud.githubusercontent.com/assets/121939/21321577/54288bdc-c60d-11e6-8368-e9e7a0272ce3.png)

## After
![screen shot 2016-12-19 at 17 05 12](https://cloud.githubusercontent.com/assets/121939/21321582/58a2300a-c60d-11e6-94ff-ed5bffe4d9cd.png)
