### PR TITLE
Redirect /service-manual/search to /search

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
   mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
+
+  get '/service-manual/search', to: redirect { |_, request|
+    query = request.query_parameters.merge(filter_manual: '/service-manual').to_query
+    "/search?#{query}"
+  }
+
   with_options format: false do |r|
     r.get 'healthcheck', to: proc { [200, {}, ['']] }
     r.get '*path' => 'content_items#show', constraints: { path: %r[.*] }

--- a/test/integration/search_redirect_test.rb
+++ b/test/integration/search_redirect_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class SearchRedirectTest < ActionDispatch::IntegrationTest
+  test 'the legacy search URL redirects to /search and retains parameters' do
+    get '/service-manual/search?q=bananas'
+    assert_redirected_to '/search?filter_manual=%2Fservice-manual&q=bananas'
+  end
+end


### PR DESCRIPTION
At the moment, requests to /service-manual/search return a 404. These
should really return a 301 round to /search, adding a `filter_manual`
parameter to scope search to the service manual.

This PR adds a new route to handle that particular situation.