### PR TITLE
Header and footer for Service Toolkit

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -6,17 +6,12 @@ class ContentItemsController < ApplicationController
   rescue_from GdsApi::HTTPForbidden, with: :error_403
 
   def show
-    # The Slimmer middleware is responsible for intercepting the response and
-    # wrapping it with the GOV.UK header and footer. We want to use our own
-    # 'report a problem' pattern, so opt out of the bundled one.
-    set_slimmer_headers(
-      report_a_problem: "false"
-    )
 
     if load_content_item
       set_expiry
       set_locale
       configure_header_search
+      configure_feedback_form
       render content_item_template
     else
       configure_header_search
@@ -72,6 +67,17 @@ private
       remove_header_search
     else
       scope_header_search_to_service_manual
+    end
+  end
+
+  def configure_feedback_form
+    # The Slimmer middleware is responsible for intercepting the response and
+    # wrapping it with the GOV.UK header and footer. We want to use our own
+    # 'report a problem' pattern, so opt out of the bundled one.
+    if @content_item.present? && @content_item.use_new_style_feedback_form?
+      set_slimmer_headers(
+        report_a_problem: "false"
+      )
     end
   end
 

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -68,7 +68,7 @@ private
   end
 
   def configure_header_search
-    if @content_item.present? && @content_item.is_homepage?
+    if @content_item.present? && !@content_item.include_search_in_header?
       remove_header_search
     else
       scope_header_search_to_service_manual

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -3,9 +3,11 @@ require 'slimmer/headers'
 
 class ContentItemsController < ApplicationController
   include Slimmer::Headers
+  include Slimmer::Template
   rescue_from GdsApi::HTTPForbidden, with: :error_403
 
   def show
+    slimmer_template :without_footer_links
 
     if load_content_item
       set_expiry

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -19,6 +19,10 @@ class ContentItemPresenter
     true
   end
 
+  def use_new_style_feedback_form?
+    true
+  end
+
 private
 
   def display_time(timestamp)

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -15,8 +15,8 @@ class ContentItemPresenter
     sorted_locales(links["available_translations"])
   end
 
-  def is_homepage?
-    false
+  def include_search_in_header?
+    true
   end
 
 private

--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -3,8 +3,8 @@ class HomepagePresenter < ContentItemPresenter
     []
   end
 
-  def is_homepage?
-    true
+  def include_search_in_header?
+    false
   end
 
   def topics

--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -2,4 +2,8 @@ class ServiceToolkitPresenter < ContentItemPresenter
   def include_search_in_header?
     false
   end
+
+  def use_new_style_feedback_form?
+    false
+  end
 end

--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -1,2 +1,5 @@
 class ServiceToolkitPresenter < ContentItemPresenter
+  def include_search_in_header?
+    false
+  end
 end

--- a/app/views/content_items/service_toolkit.html.erb
+++ b/app/views/content_items/service_toolkit.html.erb
@@ -1,3 +1,4 @@
 <%= content_for :title, "Service Toolkit" %>
+<%= content_for :header_title, "Service Toolkit" %>
 
 <h1>Service Toolkit</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
       <%= yield %>
     </main>
 
-    <%= render '/shared/improve_this_page' %>
+    <%= render '/shared/improve_this_page' if @content_item.use_new_style_feedback_form? %>
   </div>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
 </head>
 <body>
   <div class="slimmer-inside-header">
-      <h1 class="header-title">Service Manual</h1>
+      <h1 class="header-title"><%= content_for(:header_title) || "Service Manual" %></h1>
   </div>
 
   <div id="wrapper" class="<%= wrapper_class %>">

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -83,6 +83,15 @@ class ContentItemsControllerTest < ActionController::TestCase
       'the header is not set correctly'
   end
 
+  test "does not set a header to disable 'report a problem' for the Service Toolkit" do
+    content_item = content_store_has_schema_example('service_manual_service_toolkit', 'service_manual_service_toolkit')
+
+    get :show, path: path_for(content_item)
+
+    refute response.headers.key?('X-Slimmer-Report-a-Problem'),
+      'Report a problem should not be disabled'
+  end
+
   test 'guides should tell slimmer to scope search results to the manual' do
     content_item = content_store_has_schema_example('service_manual_guide', 'service_manual_guide')
 

--- a/test/integration/service_toolkit_test.rb
+++ b/test/integration/service_toolkit_test.rb
@@ -6,4 +6,11 @@ class ServiceToolkitTest < ActionDispatch::IntegrationTest
 
     assert page.has_title? "Service Toolkit"
   end
+
+  test 'the service toolkit does not include the new style feedback form' do
+    setup_and_visit_example('service_manual_service_toolkit', 'service_manual_service_toolkit')
+
+    refute page.has_css?('.improve-this-page'),
+      'Improve this page component should not be present on the page'
+  end
 end


### PR DESCRIPTION
- Override the header title to 'Service Toolkit'
- Remove the search field
- Use the 'old style' feedback form for the Service Toolkit
- Remove the footer links in both the Service Toolkit and the Service Manual