### PR TITLE
Do not display reason for change in change history

### DIFF
--- a/app/assets/stylesheets/modules/_change-history.scss
+++ b/app/assets/stylesheets/modules/_change-history.scss
@@ -14,8 +14,7 @@
     }
   }
 
-  &__summary,
-  &__reason {
+  &__summary {
     @include core-16;
     color: $grey-1;
   }

--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -1,6 +1,6 @@
 class GuidePresenter < ContentItemPresenter
   ContentOwner = Struct.new(:title, :href)
-  Change = Struct.new(:public_timestamp, :note, :reason_for_change)
+  Change = Struct.new(:public_timestamp, :note)
 
   attr_reader :body, :publish_time, :header_links
 
@@ -47,8 +47,7 @@ class GuidePresenter < ContentItemPresenter
     if change.present?
       Change.new(
         visible_updated_at,
-        change["note"],
-        change["reason_for_change"]
+        change["note"]
       )
     end
   end
@@ -57,8 +56,7 @@ class GuidePresenter < ContentItemPresenter
     change_history.drop(1).map do |change|
       Change.new(
         change["public_timestamp"].to_time,
-        change["note"],
-        change["reason_for_change"]
+        change["note"]
       )
     end
   end

--- a/app/views/shared/_change_history.html.erb
+++ b/app/views/shared/_change_history.html.erb
@@ -3,7 +3,3 @@
 <p class="change-history__summary">
   <%= change.note %>
 </p>
-
-<div class="change-history__reason">
-  <%= simple_format(change.reason_for_change) %>
-</div>

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -102,7 +102,6 @@ class GuideTest < ActionDispatch::IntegrationTest
 
     within('.change-history') do
       assert page.has_content? 'This is our latest change'
-      assert page.has_content? 'This is the reason for our latest change'
     end
   end
 
@@ -111,8 +110,6 @@ class GuideTest < ActionDispatch::IntegrationTest
 
     within('.change-history__past') do
       assert page.has_content? 'This is another change'
-      assert page.has_content? 'This is why we made this change and it has a second line of text'
-
       assert page.has_content? 'Guidance first published'
     end
   end
@@ -123,8 +120,7 @@ class GuideTest < ActionDispatch::IntegrationTest
         "change_history" => [
           {
             "public_timestamp"  => "2015-09-01T08:17:10+00:00",
-            "note"  => "Guidance first published",
-            "reason_for_change" => ""
+            "note"  => "Guidance first published"
           }
         ]
       })

--- a/test/presenters/guide_presenter_test.rb
+++ b/test/presenters/guide_presenter_test.rb
@@ -111,8 +111,7 @@ class GuidePresenterTest < ActiveSupport::TestCase
   test '#latest_change returns the details for the most recent change' do
     expected_history = GuidePresenter::Change.new(
       "2015-10-09T08:17:10+00:00".to_time,
-      "This is our latest change",
-      "This is the reason for our latest change"
+      "This is our latest change"
     )
 
     assert_equal expected_history, presented_guide.latest_change
@@ -131,8 +130,7 @@ class GuidePresenterTest < ActiveSupport::TestCase
 
     expected_history = GuidePresenter::Change.new(
       timestamp.to_time,
-      "This is our latest change",
-      "This is the reason for our latest change"
+      "This is our latest change"
     )
 
     assert_equal expected_history, guide.latest_change
@@ -142,13 +140,11 @@ class GuidePresenterTest < ActiveSupport::TestCase
     expected_history = [
       GuidePresenter::Change.new(
         "2015-09-09T08:17:10+00:00".to_time,
-        "This is another change",
-        "This is why we made this change\nand it has a second line of text"
+        "This is another change"
       ),
       GuidePresenter::Change.new(
         "2015-09-01T08:17:10+00:00".to_time,
-        "Guidance first published",
-        ""
+        "Guidance first published"
       )
     ]
 


### PR DESCRIPTION
The ‘reason for change’ often duplicates the change note so is being removed to prevent duplication and confusion.

There will be follow up work to remove the reason for change from the content schemas and the Service Manual Publisher.