### PR TITLE
Add anchors to collections on toolkit page

### DIFF
--- a/app/views/content_items/service_toolkit.html.erb
+++ b/app/views/content_items/service_toolkit.html.erb
@@ -20,7 +20,7 @@
 <div class="full-page-width-wrapper">
   <% @content_item.collections.each do |collection| %>
   <div class="collection">
-    <h2 class="collection__title"><%= collection["title"] %></h2>
+    <h2 id="<%= collection["title"].parameterize %>" class="collection__title"><%= collection["title"] %></h2>
     <p class="collection__description"><%= collection["description"] %></p>
 
     <% collection["links"].each_slice(2) do |row_of_links| %>


### PR DESCRIPTION
We want to be able to ‘deep link’ directly to e.g. the collection of components. Providing an ID allows us to do this using the hash part of the URL.

https://trello.com/c/1e6QTqAQ/558-add-anchors-to-service-toolkit