### PR TITLE
Fix vertical alignment

### DIFF
--- a/app/assets/stylesheets/modules/_service-standard-point.scss
+++ b/app/assets/stylesheets/modules/_service-standard-point.scss
@@ -6,6 +6,10 @@
   margin-top: 1.5em;
   padding-top: 1.5em;
 
+  &:first-child {
+    margin-top: 0;
+  }
+
   &__title {
     @include bold-24;
     margin-bottom: 0.5em;


### PR DESCRIPTION
Removing the top margin for the first service standard point vertical aligns it with the notifications sidebar

**Before:**
![screen shot 2017-01-18 at 11 52 48](https://cloud.githubusercontent.com/assets/523014/22073824/53e16e0c-dd9e-11e6-9f66-c3a40ad08506.png)

**After:**
![screen shot 2017-01-18 at 16 50 38](https://cloud.githubusercontent.com/assets/523014/22073834/59e160aa-dd9e-11e6-96c6-070314fb15dd.png)
