### PR TITLE
Add schema test support to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,9 +20,29 @@ node {
       paramsToUseForLimit: REPOSITORY,
       throttleEnabled: true,
       throttleOption: 'category'],
+    [$class: 'ParametersDefinitionProperty',
+      parameterDefinitions: [
+        [$class: 'BooleanParameterDefinition',
+          name: 'IS_SCHEMA_TEST',
+          defaultValue: false,
+          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
+        [$class: 'StringParameterDefinition',
+          name: 'SCHEMA_BRANCH',
+          defaultValue: 'deployed-to-production',
+          description: 'The branch of govuk-content-schemas to test against']]
+    ],
   ])
 
   try {
+    govuk.initializeParameters([
+      'IS_SCHEMA_TEST': 'false',
+      'SCHEMA_BRANCH': 'deployed-to-production',
+    ])
+
+    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
+      return
+    }
+
     stage("Build") {
       checkout scm
 
@@ -31,8 +51,8 @@ node {
 
       govuk.setEnvar("RAILS_ENV", "test")
       govuk.bundleApp()
-      
-      govuk.contentSchemaDependency()
+
+      govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
       govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
 
       govuk.precompileAssets()


### PR DESCRIPTION
This adds support for running schema tests in govuk-content-schemas.

For more information, see [here](https://github.gds/gds/opsmanual/pull/862/files?short_path=db37eb8#diff-db37eb8a3f2b8b7408aa69b7a0435c61).