### PR TITLE
Remove flaky "improve this page" test

### DIFF
--- a/test/integration/improve_this_page_test.rb
+++ b/test/integration/improve_this_page_test.rb
@@ -17,25 +17,4 @@ class ImproveThisPageTest < ActionDispatch::IntegrationTest
       assert page.has_link?('Is there anything wrong with this page?', href: '/contact/govuk')
     end
   end
-
-  test "asks the user for feedback if there is something wrong with the page" do
-    using_javascript_driver do
-      setup_and_visit_example('service_manual_guide', 'service_manual_guide')
-
-      assert feedback_form_is_hidden
-
-      within('.improve-this-page') do
-        page.click_link 'No'
-      end
-
-      refute feedback_form_is_hidden
-    end
-  end
-
-  # Because the CSS for .js-hidden is hosted outside of this app, we test for the presence
-  # of the class rather than rely on PhantomJS to know whether the element is visible
-  # or not.
-  def feedback_form_is_hidden
-    page.has_css?(%{.js-feedback-form[class*="js-hidden"]})
-  end
 end


### PR DESCRIPTION
This test is extremely unreliable, both on CI and locally.

I've tried various things in an attempt to improve its reliability:
- Changing the selector (to `.js-feedback-form.js-hidden`)
- Adding a `sleep`
- Setting a high `wait` on the `has_css?` call
- Removing the first `assert`

None of these solutions fix the build reliably. Adding a `sleep` or
increasing the `wait` time seems to make it occur less, but means that
the build can take huge amounts of time to complete if the element isn't
found for whatever reason (which appears to be the root cause of the
issue).

Changing the underlying Capybara driver to capybara-webkit _does_
increase reliability, however it's difficult to run on CI and massively
increases the complexity of running the test suite.

To that end – the simplest course of action appears to be to simply
remove the test entirely. It's testing JavaScript which is outside our
application (hence why this test exists in Ruby, rather than being a
Jasmine spec), and subsequently perhaps shouldn't be here in the first
place.