### PR TITLE
Fix JavaScript tests of accordion session storage

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -109,7 +109,7 @@
         $subsectionContent.each(function(index) {
           var subsectionContentId = $(this).attr('id');
           if(sessionStorage.getItem(GOVUKServiceManualTopic+subsectionContentId)){
-            openStoredSections($("#"+subsectionContentId));
+            openStoredSections($element.find("#"+subsectionContentId));
           }
         });
 
@@ -117,9 +117,9 @@
       }
 
       function setSessionStorage() {
-        var isOpenSubsections = $('.subsection--is-open').length;
+        var isOpenSubsections = $element.find('.subsection--is-open').length;
         if (isOpenSubsections) {
-          var $openSubsections = $('.subsection--is-open');
+          var $openSubsections = $element.find('.subsection--is-open');
           $openSubsections.each(function(index) {
             var subsectionOpenContentId = $(this).find('.subsection__content').attr('id');
             sessionStorage.setItem( GOVUKServiceManualTopic+subsectionOpenContentId , 'Opened');
@@ -128,9 +128,9 @@
       }
 
       function removeSessionStorage() {
-        var isClosedSubsections = $('.subsection').length;
+        var isClosedSubsections = $element.find('.subsection').length;
         if (isClosedSubsections) {
-          var $closedSubsections = $('.subsection');
+          var $closedSubsections = $element.find('.subsection');
           $closedSubsections.each(function(index) {
             var subsectionClosedContentId = $(this).find('.subsection__content').attr('id');
             sessionStorage.removeItem( GOVUKServiceManualTopic+subsectionClosedContentId , subsectionClosedContentId);
@@ -217,7 +217,7 @@
       }
 
       function setOpenCloseAllText() {
-        var openSubsections = $('.subsection--is-open').length;
+        var openSubsections = $element.find('.subsection--is-open').length;
         // Find out if the number of is-opens == total number of sections
         if (openSubsections === totalSubsections) {
           $openOrCloseAllButton.text('Close all');

--- a/spec/javascripts/accordion-with-descriptions-spec.js
+++ b/spec/javascripts/accordion-with-descriptions-spec.js
@@ -42,6 +42,7 @@ describe('An accordion with descriptions module', function () {
 
   afterEach(function() {
     $(document).off();
+    sessionStorage.clear();
   });
 
   it("has a class of js-accordion-with-descriptions to indicate the js has loaded", function () {
@@ -188,14 +189,13 @@ describe('An accordion with descriptions module', function () {
     it("has its state saved in session storage", function () {
       accordion.start($element);
 
-      var GOVUKServiceManualTopic = "GOVUK_service_manual_agile_delivery";
+      var GOVUKServiceManualTopic = "GOVUK_service_manual__";
 
       var $subsectionButton = $element.find('.subsection__title button');
       $subsectionButton.click();
 
-      var $openSubsections = $('.subsection--is-open');
+      var $openSubsections = $element.find('.subsection--is-open');
       var subsectionOpenContentId = $openSubsections.find('.subsection__content').attr('id');
-      sessionStorage.setItem(GOVUKServiceManualTopic+subsectionOpenContentId , 'Opened');
 
       var storedItem = sessionStorage.getItem(GOVUKServiceManualTopic+subsectionOpenContentId);
       expect(storedItem).toEqual('Opened');
@@ -270,13 +270,18 @@ describe('An accordion with descriptions module', function () {
     it("has its state removed in session storage", function () {
       accordion.start($element);
 
-      var GOVUKServiceManualTopic = "GOVUK_service_manual_agile_delivery";
+      var GOVUKServiceManualTopic = "GOVUK_service_manual__";
 
-      var $closedSubsections = $element.find('.subsection');
-      var subsectionClosedContentId = $closedSubsections.find('.subsection__content').attr('id');
-      sessionStorage.removeItem(GOVUKServiceManualTopic+subsectionClosedContentId , 'Opened');
-      var removedItem = sessionStorage.getItem(GOVUKServiceManualTopic+subsectionClosedContentId);
-      expect(removedItem).not.toExist();
+      var $subsection = $element.find('.subsection');
+      var $subsectionButton = $subsection.find('.subsection__title button');
+
+      // Open and close the subsection
+      $subsectionButton.click();
+      $subsectionButton.click();
+
+      var subsectionContentId = $subsection.find('.subsection__content').attr('id');
+      var storedItem = sessionStorage.getItem(GOVUKServiceManualTopic+subsectionContentId);
+      expect(storedItem).toBeNull();
     });
 
     it("triggers a google analytics custom event when clicking on the title", function () {


### PR DESCRIPTION
Spotted while porting the accordion analytics tracking to collections.

The Jasmine tests were manipulating the session state in the test code, which meant that they were not fully testing that the application code.

This fixes the problem by removing all state changes in the tests except for resetting the session storage after each test.

To support this, some jQuery selectors have also been updated from `$('foo')` to `$element.find('foo')`. This doesn't change the behaviour in the browse, but it makes the code more consistent (since `find` was already being used elsewhere) and it means that the selector is correctly applied to the HTML fixture in the tests.