### PR TITLE
Add option to download service standard poster

### DIFF
--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -1,4 +1,11 @@
 class ServiceStandardPresenter < ContentItemPresenter
+  attr_reader :poster_url
+
+  def initialize(*)
+    super
+    @poster_url = details["poster_url"]
+  end
+
   def points
     Point.load(points_attributes).sort
   end

--- a/app/views/content_items/service_standard.html.erb
+++ b/app/views/content_items/service_standard.html.erb
@@ -55,6 +55,17 @@
         </p>
       </div>
     <% end %>
+
+    <% if @content_item.poster_url.present? %>
+      <div class="related-item">
+        <h2 class="related-item__title" id="download-poster">
+          Download the poster
+        </h2>
+        <p class="related-item__description">
+          <%= link_to "Download and print your own Digital Service Standard poster", @content_item.poster_url %>
+        </p>
+      </div>
+    <% end %>
     </aside>
   </div>
 </div>

--- a/test/presenters/service_standard_presenter_test.rb
+++ b/test/presenters/service_standard_presenter_test.rb
@@ -70,6 +70,10 @@ class ServiceStandardPresenterTest < ActiveSupport::TestCase
     assert_nil presented_standard(links: { email_alert_signup: [] }).email_alert_signup_link
   end
 
+  test "#poster_url returns a link to the service standard poster" do
+    assert_equal "http://example.com/service-standard-poster.pdf", presented_standard.poster_url
+  end
+
 private
 
   def presented_standard(overriden_attributes = {})


### PR DESCRIPTION
This adds a new attribute on the `ServiceStandardPresenter` and
associated bit of UI to allow users to download a PDF of the service
standard for sticking on a wall.

Dependent on alphagov/govuk-content-schemas#524.