### PR TITLE
Allow "improve this page" form to be closed

### DIFF
--- a/app/assets/javascripts/modules/improve-this-page.js
+++ b/app/assets/javascripts/modules/improve-this-page.js
@@ -22,6 +22,7 @@
     this.$feedbackFormContainer = $element.find('.js-feedback-form');
     this.$feedbackForm = that.$feedbackFormContainer.find('form');
     this.$feedbackFormSubmitButton = that.$feedbackFormContainer.find('[type=submit]');
+    this.$feedbackFormCloseButton = that.$feedbackFormContainer.find('.js-close-feedback-form');
     this.$prompt = $element.find('.js-prompt');
 
     this.onPageIsUsefulButtonClicked = function (callback) {
@@ -36,6 +37,10 @@
       that.$somethingIsWrongButton.on('click', preventingDefault(callback));
     }
 
+    this.onFeedbackFormCloseButtonClicked = function (callback) {
+      that.$feedbackFormCloseButton.on('click', preventingDefault(callback));
+    }
+
     this.onSubmitFeedbackForm = function (callback) {
       that.$feedbackForm.on('submit', preventingDefault(callback));
     }
@@ -48,9 +53,9 @@
       $element.html('Sorry, we’re unable to receive your message right now. We have other ways for you to provide feedback on the <a href=\"/contact/govuk\">contact page</a>.');
     }
 
-    this.showFeedbackForm = function () {
-      that.$prompt.addClass('js-hidden');
-      that.$feedbackFormContainer.removeClass('js-hidden');
+    this.toggleFeedbackForm = function () {
+      that.$prompt.toggleClass('js-hidden');
+      that.$feedbackFormContainer.toggleClass('js-hidden');
     }
 
     this.feedbackFormContainerData = function () {
@@ -127,6 +132,7 @@
       that.bindPageIsNotUsefulButton();
       that.bindSomethingIsWrongButton();
       that.bindSubmitFeedbackButton();
+      this.bindCloseFeedbackFormButton();
     }
 
     this.bindPageIsUsefulButton = function () {
@@ -143,7 +149,7 @@
       var handler = function () {
         that.trackEvent(view.pageIsNotUsefulTrackEventParams());
 
-        view.showFeedbackForm();
+        view.toggleFeedbackForm();
       }
 
       view.onPageIsNotUsefulButtonClicked(handler);
@@ -153,10 +159,18 @@
       var handler = function () {
         that.trackEvent(view.somethingIsWrongTrackEventParams());
 
-        view.showFeedbackForm();
+        view.toggleFeedbackForm();
       }
 
       view.onSomethingIsWrongButtonClicked(handler);
+    }
+
+    this.bindCloseFeedbackFormButton = function () {
+      var handler = function () {
+        view.toggleFeedbackForm();
+      }
+
+      view.onFeedbackFormCloseButtonClicked(handler);
     }
 
     this.bindSubmitFeedbackButton = function () {

--- a/app/assets/stylesheets/modules/_improve-this-page.scss
+++ b/app/assets/stylesheets/modules/_improve-this-page.scss
@@ -1,6 +1,8 @@
 .improve-this-page {
+  $container-padding: 10px;
+
   position: relative;
-  padding: 10px 10px 0;
+  padding: $container-padding $container-padding 0;
   background-color: $govuk-blue;
   color: $white;
 
@@ -50,6 +52,18 @@
 
   &__error:first-letter {
     text-transform: capitalize;
+  }
+
+  &__close {
+    position: absolute;
+    top: $container-padding;
+    right: $container-padding;
+    padding-top: 5px;
+    @include core-16;
+
+    @include media(tablet) {
+      padding-top: 0;
+    }
   }
 
   @include print {

--- a/app/views/shared/_improve_this_page.html.erb
+++ b/app/views/shared/_improve_this_page.html.erb
@@ -25,6 +25,7 @@
       <% end %>
     </div>
     <div class="js-feedback-form js-hidden" data-track-category="manualFeedbackForm" data-track-action="ffFormSubmit">
+      <a href="#" class="improve-this-page__close js-close-feedback-form" aria-hidden="true">Close</a>
       <div class="grid-row">
         <div class="column-two-thirds">
           <div class="js-errors"></div>

--- a/spec/javascripts/improve-this-page-spec.js
+++ b/spec/javascripts/improve-this-page-spec.js
@@ -10,6 +10,7 @@ describe("Improve this page", function () {
         '</div>' +
       '</div>' +
       '<div class="js-feedback-form js-hidden" data-track-category="improve-this-page" data-track-action="give-feedback">' +
+        '<a href="#" class="improve-this-page__close js-close-feedback-form" aria-hidden="true">Close</a>' +
         '<div class="js-errors"></div>' +
         '<form>' +
           '<input type="hidden" name="url" value="http://example.com/path/to/page"></input>' +
@@ -243,6 +244,16 @@ describe("Improve this page", function () {
       });
 
       expect($('.improve-this-page').html()).toBe("Sorry, we’re unable to receive your message right now. We have other ways for you to provide feedback on the <a href=\"/contact/govuk\">contact page</a>.");
+    });
+
+    it("hides the form when the close button is pressed", function() {
+      loadImproveThisPage();
+
+      $('a.js-page-is-not-useful').click();
+      $('a.js-close-feedback-form').click();
+
+      expect($('.improve-this-page .js-prompt')).not.toHaveClass('js-hidden');
+      expect($('.improve-this-page .js-feedback-form')).toHaveClass('js-hidden');
     });
   });
 


### PR DESCRIPTION
At the moment, if I'm shown the feedback form in the improve this page
component, there's no way to close it. This is apparently rather
annoying, particularly on smaller viewports, so this adds a "Close" link
allowing users to close it.