### PR TITLE
Raise better errors for unsupported formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,25 @@ This is a Ruby on Rails application that fetches documents from
 
 ### Running the application
 
-`./startup.sh`
+You can use [Bowler](https://github.com/JordanHatch/bowler) to automatically run
+the application and all of its dependencies. To do this, you'll need to check
+out the [development repository](https://github.gds/gds/development) where the
+`Pinfile` is located.
 
-The app should start on http://localhost:3122 or
-http://service-manual-frontend.dev.gov.uk on GOV.UK development machines.
+```
+cd /var/govuk/development
+bowl service-manual-frontend
+```
+
+Alternatively, run `./startup.sh` in the `service-manual-frontend` directory.
+
+```
+cd /var/govuk/service-manual-frontend
+./startup.sh
+```
+
+The application runs on port `3122` by default. If you're using the GDS VM it'll
+be available at http://service-manual-frontend.dev.gov.uk.
 
 Note that the application *does not serve content at its root (/)* - the
 homepage will be found at service-manual-frontend.dev.gov.uk/service-manual but

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ This is a Ruby on Rails application that fetches documents from
 The app should start on http://localhost:3122 or
 http://service-manual-frontend.dev.gov.uk on GOV.UK development machines.
 
+Note that the application *does not serve content at its root (/)* - the
+homepage will be found at service-manual-frontend.dev.gov.uk/service-manual but
+only if the content item for the homepage exists in the content store.
+
+You can achieve this by restoring from a production backup, publishing the home
+page using the rake task in service-manual-publisher or by using the dummy
+content store.
+
 ### Running the test suite
 
 The test suite relies on the presence of the

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -39,7 +39,18 @@ private
     presenter_class = Object.const_get(presenter_name)
     presenter_class.new(content_item)
   rescue NameError
-    raise "No support for format \"#{content_item['format']}\""
+    if content_item['base_path'] == '/'
+      raise <<~ERROR
+        This application does not serve anything at its root. The homepage, if
+        published in the content store, can be found at /service-manual.
+        See the README for more information.
+      ERROR
+    else
+      raise <<~ERROR
+        The content item at base path #{content_item['base_path']} is of format
+        \"#{content_item['format']}\", which this application does not support.
+      ERROR
+    end
   end
 
   def content_item_template


### PR DESCRIPTION
Users will often visit the root of an application when they first start it, to make sure it is working. At the minute, we throw an exception if you try to do this. This is intentional – applications should serve on the routes as they would appear on GOV.UK, so the service manual shouldn’t do anything for `/` – it’s homepage is at `/service-manual`.

However, the exception we throw (No support for format special_route) does not make this obvious. This handles the root as a special case, tries to makes the general error message more useful as well, and adds some documentation to the README.

![screen shot 2017-03-08 at 13 44 46](https://cloud.githubusercontent.com/assets/121939/23706316/9cbd82d6-0405-11e7-95dc-317b878e752d.png)
![screen shot 2017-03-08 at 13 46 09](https://cloud.githubusercontent.com/assets/121939/23706317/9cbef8fa-0405-11e7-9d17-3c422a55b577.png)
