### PR TITLE
Use document type instead of format

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -34,7 +34,7 @@ private
   end
 
   def present(content_item)
-    class_name = content_item['format'].sub(/^service_manual_/, '').classify
+    class_name = content_item['document_type'].sub(/^service_manual_/, '').classify
     presenter_name = class_name + 'Presenter'
     presenter_class = Object.const_get(presenter_name)
     presenter_class.new(content_item)
@@ -47,8 +47,9 @@ private
       ERROR
     else
       raise <<~ERROR
-        The content item at base path #{content_item['base_path']} is of format
-        \"#{content_item['format']}\", which this application does not support.
+        The content item at base path #{content_item['base_path']} is of
+        document_type \"#{content_item['document_type']}\", which this
+        application does not support.
       ERROR
     end
   end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -30,7 +30,7 @@ class ContentItemPresenter
   end
 
   def format
-    content_item["format"].sub(/^service_manual_/, '')
+    content_item["document_type"].sub(/^service_manual_/, '')
   end
 
 private

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -1,5 +1,5 @@
 class ContentItemPresenter
-  attr_reader :content_item, :title, :description, :format, :locale, :phase, :links
+  attr_reader :content_item, :title, :description, :locale, :phase, :links
 
   def initialize(content_item)
     @content_item = content_item

--- a/test/presenters/content_item_presenter_test.rb
+++ b/test/presenters/content_item_presenter_test.rb
@@ -11,7 +11,7 @@ class ContentItemPresenterTest < ActiveSupport::TestCase
 
   test "#format" do
     assert_equal "a_format",
-      ContentItemPresenter.new("format" => "service_manual_a_format").format
+      ContentItemPresenter.new("document_type" => "service_manual_a_format").format
   end
 
   test "#locale" do


### PR DESCRIPTION
The format field has been deprecated and is now being removed, so we should use `document_type` instead.

Related to alphagov/govuk-content-schemas#598