### PR TITLE
Fix alignment of feedback form on Service Toolkit

### DIFF
--- a/app/assets/stylesheets/hacks/_full-width.scss
+++ b/app/assets/stylesheets/hacks/_full-width.scss
@@ -15,7 +15,9 @@
     border-bottom: none;
   }
 
-  .full-page-width-wrapper {
+  .full-page-width-wrapper,
+  #wrapper .report-a-problem-toggle-wrapper,
+  #wrapper .report-a-problem-container {
     @extend %site-width-container;
   }
 }


### PR DESCRIPTION
For the service toolkit, we override the wrapper to make it full width to allow for the full width masthead. This means that it doesn’t center the feedback form and its toggle as it does on other pages on GOV.UK.

Sadly this means we need to add more hacks to explicitly center the feedback form and its toggle when this full width override is in place.

## Before

![screen shot 2017-09-01 at 15 12 38](https://user-images.githubusercontent.com/121939/29973589-049fe4c2-8f28-11e7-8167-4567f6811250.png)

## After

![screen shot 2017-09-01 at 15 12 29](https://user-images.githubusercontent.com/121939/29973597-09fd1b7e-8f28-11e7-94c8-802629cc2cc8.png)
