### PR TITLE
Update govuk-content-schemas-test-helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :test do
   gem 'capybara'
   gem 'poltergeist'
   gem 'webmock', '~> 1.18.0', require: false
-  gem 'govuk-content-schema-test-helpers', '1.1.0'
+  gem 'govuk-content-schema-test-helpers', '~> 1.5'
   gem 'pry-byebug'
   gem 'rails-controller-testing'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
-    govuk-content-schema-test-helpers (1.1.0)
+    govuk-content-schema-test-helpers (1.5.0)
       json-schema (~> 2.5.1)
     govuk-lint (3.3.0)
       rubocop (~> 0.49.0)
@@ -287,7 +287,7 @@ DEPENDENCIES
   binding_of_caller
   capybara
   gds-api-adapters (~> 47.9.1)
-  govuk-content-schema-test-helpers (= 1.1.0)
+  govuk-content-schema-test-helpers (~> 1.5)
   govuk-lint
   govuk_app_config (~> 0.2.0)
   govuk_elements_rails


### PR DESCRIPTION
To try avoid the build breaking when
https://github.com/alphagov/govuk-content-schemas/pull/634
is merged