### PR TITLE
Use standard buildProject in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,85 +1,17 @@
 #!/usr/bin/env groovy
 
-REPOSITORY = 'service-manual-frontend'
-
 node {
   // Deployed by Puppet's Govuk_jenkins::Pipeline manifest
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
-  properties([
-    buildDiscarder(
-      logRotator(
-        numToKeepStr: '50')
-      ),
-    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
-    [$class: 'ThrottleJobProperty',
-      categories: [],
-      limitOneJobWithMatchingParams: true,
-      maxConcurrentPerNode: 1,
-      maxConcurrentTotal: 0,
-      paramsToUseForLimit: REPOSITORY,
-      throttleEnabled: true,
-      throttleOption: 'category'],
-    [$class: 'ParametersDefinitionProperty',
-      parameterDefinitions: [
-        [$class: 'BooleanParameterDefinition',
-          name: 'IS_SCHEMA_TEST',
-          defaultValue: false,
-          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
-        [$class: 'StringParameterDefinition',
-          name: 'SCHEMA_BRANCH',
-          defaultValue: 'deployed-to-production',
-          description: 'The branch of govuk-content-schemas to test against']]
-    ],
-  ])
-
-  try {
-    govuk.initializeParameters([
-      'IS_SCHEMA_TEST': 'false',
-      'SCHEMA_BRANCH': 'deployed-to-production',
-    ])
-
-    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
-      return
+  govuk.buildProject(
+    overrideTestTask: {
+      stage("Run tests") {
+        govuk.withStatsdTiming("test_task") {
+          govuk.runRakeTask('test')
+          govuk.runRakeTask("spec:javascript")
+        }
+      }
     }
-
-    stage("Build") {
-      checkout scm
-
-      govuk.cleanupGit()
-      govuk.mergeMasterBranch()
-
-      govuk.setEnvar("RAILS_ENV", "test")
-      govuk.bundleApp()
-
-      govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
-      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
-
-      govuk.precompileAssets()
-    }
-
-    stage("Lint") {
-      govuk.sassLinter()
-      govuk.rubyLinter()
-    }
-
-    stage("Test") {
-      govuk.runRakeTask('test')
-      govuk.runRakeTask("spec:javascript")
-    }
-
-    stage("Deploy") {
-      // pushTag and deployIntegration are no-ops unless on master branch
-      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
-      govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
-    }
-
-  } catch (e) {
-    currentBuild.result = "FAILED"
-    step([$class: 'Mailer',
-          notifyEveryUnstableBuild: true,
-          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
-          sendToIndividuals: true])
-    throw e
-  }
+  )
 }


### PR DESCRIPTION
For: https://trello.com/c/QtpGwa2A/288-improve-feedback-on-github-for-changes-to-govuk-content-schemas

Using the standard buildProject defined in our groovy library means we get
consistent behaviour across all applications, and allows us to improve our
CI process in one place.

The only difference between our custom Jenkinsfile and buildProject is
that we need to use `overrideTestTask` to run `rake test` followed by
`rake spec:javascript`.  Left to its own devices `buildProject` would
run `rake default` which in our case would run lint again, and that's
already run by the Jenkinsfile in a previous stage so we don't want to
double up our effort.