### PR TITLE
Make sure the `Dockerfile` is in sync with `.ruby-version`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y
 
 RUN apt-get install -y build-essential nodejs && apt-get clean


### PR DESCRIPTION
Our `.ruby-version` is 2.4.2 so we need to use the `ruby:2.4.2` base image
for our `Dockerfile`.