### PR TITLE
Be more selective about govuk_toolkit requires in application.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,10 @@
-// from govuk_frontend_toolkit
+// from govuk_frontend_toolkit and not delivered by static as part of
+// header-footer-only on deployed environments
 //= require govuk/stick-at-top-when-scrolling
 //= require govuk/stop-scrolling-at-footer
-//= require_tree .
+//
+//= require_tree ./govuk
+//= require_tree ./modules
 
 window.GOVUK.stickAtTopWhenScrolling.init();
 window.GOVUK.stopScrollingAtFooter.addEl($('.js-stick-at-top-when-scrolling'));

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -1,7 +1,6 @@
+// This is a manifest file only included in test environments
 // from govuk_frontend_toolkit
 //= require govuk/modules
-
-//= require modules/accordion-with-descriptions
 
 $(document).ready(function () {
   GOVUK.modules.start();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
   <%= stylesheet_link_tag "print", media: "print" %>
 
   <%= javascript_include_tag 'application' %>
+  <%= javascript_include_tag 'start-modules' if Rails.env.test? %>
   <%= csrf_meta_tags %>
   <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item.content_item } %>
   <% if content_for(:meta_description).present? %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -19,3 +19,4 @@ Rails.application.config.assets.precompile += %w(
   screen-ie8.css
   print.css
 )
+Rails.application.config.assets.precompile += %w(start-modules) if Rails.env.test?


### PR DESCRIPTION
For: https://trello.com/c/AK6V1hHg/103-sort-out-govuktoolkit-use-in-frontend-apps-to-avoid-object-object-in-ga

When the application is deployed we get the govuk_toolkit js files from
static, if we also include them in our own JS bundle we:

1. make users effectively download the same code twice
2. run the risk of delivering two different versions of the code and
   causing errors in how things interact
3. run the risk of delivering two versions of the code that interact
   strangely because they end up redefininig things and cause things
   like type-checks to fail

Of course, if we rely on static to deliver this JS we won't have it in
test environments and so JS that relies on it can fail.  To get around
this problem we can include a separate JS file that does include the
bits we need only in testing environments.  To this end we've made it
clearer in `application.js` which bits of `govuk_frontend_toolkit` we can
include directly (e.g. those bits that wouldn't be delivered to us by the
`header-footer-only` layout we get from static) and made
`start-modules.js` (which includes the govuk/modules function that allows
the application to start all our modules from
`app/assets/javascript/modules`) into a test only manifest.  We also add
a comment to the top of that file making it clearer what its purpose is.

It's worth noting that 2. and 3. are not hypothetical. When we added PII
stripping functionality to govuk_frontend_toolkit and delivered it via
static we saw both of these problems. 1st: the version of the JS included
in the frontend apps was out of sync with the version delivered by static
so it didn't understand the PIISafe object at all and would raise errors
when trying to call that function, resulting in no analytics being sent.
2nd: after updating the govuk_frontend_toolkit version in the apps so it
was in sync with that delivered by static, we saw custom dimension values
of [object Object] being sent to analytics because the two versions on
the page disagreed about the type of Analytics.PIISafe instances and
didn't extract the value correctly.

Removing the govuk_toolkit requires from our application.js that we don't
need avoids this entirely.