### PR TITLE
Fix Heroku review apps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,7 +389,7 @@ DEPENDENCIES
   wraith (~> 4.0)
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.4.4p296
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
The Ruby version is out of sync with the Gemfile, causing Heroku deploys to fail.