### PR TITLE
Change beta phase banner content

### DIFF
--- a/app/views/shared/_custom_phase_message.html.erb
+++ b/app/views/shared/_custom_phase_message.html.erb
@@ -1,1 +1,1 @@
-This is new guidance. Complete our quick 5-question survey to <%= link_to 'help us improve it', survey_url, target: "_blank", rel: "noopener noreferrer" %>.
+Complete our quick 5-question survey to <%= link_to "help us improve our content", survey_url, target: "_blank", rel: "noopener noreferrer" %>.


### PR DESCRIPTION
## Summary

The Service Manual has a custom phase banner. It tells users content is new when it isn't. This PR: 

+ changes the banner wording so it doesn't say the content is new
+ updates the phase banner test so it won't fail because of the wording change

**Please note I'm a content designer and have a very limited idea of what I'm doing.**

## Background

On "guides", the phase banner says "This is new guidance. Complete our quick 5-question survey to help us improve it."

A lot of the guidance isn't new - it's been around for over a year in some cases. The age of the guidance is shown to users under the guide's top heading so the contrast is rather jarring. 

For example: https://www.gov.uk/service-manual/design/naming-your-service.

The homepage version of the banner doesn't have the 'This is new' phrase, so I've just updated the version that shows on guides to match the homepage version.




