### PR TITLE
Add machine readable metadata

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -1,6 +1,10 @@
 <%= content_for :title, "#{@content_item.title} - Service Manual" %>
 <% content_for :meta_description, @content_item.description %>
 
+<% content_for :extra_head do %>
+  <%= render 'govuk_publishing_components/components/machine_readable_metadata', content_item: @content_item.content_item, schema: :article %>
+<% end %>
+
 <% content_for :phase_message do %>
   <%= render 'shared/custom_phase_message', phase: @content_item.phase %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
   <%= javascript_include_tag 'start-modules' if Rails.env.test? %>
   <%= csrf_meta_tags %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item.content_item %>
+  <%= yield(:extra_head) %>
   <% if content_for(:meta_description).present? %>
     <meta name="description" content="<%= content_for(:meta_description) %>" />
   <% end %>


### PR DESCRIPTION
Adding this component will add schema.org metadata, Facebook/OpenGraph tags, Twitter card tags and a canonical tag for content pages.

https://trello.com/c/gKHoUGuA