### PR TITLE
Use govspeak component from gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'rails', '~> 5.2.0'
 gem 'rails-i18n', '~> 5.1.1'
 gem 'rails_translation_manager', '~> 0.0.2'
 gem 'sass-rails', '~> 5.0.6'
-gem 'slimmer', '~> 12.1.0'
+gem 'slimmer', '~> 13.0.0'
 gem 'uglifier', '>= 1.3.0'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,7 @@ GEM
       rubyzip (~> 1.0)
     sentry-raven (2.7.3)
       faraday (>= 0.7.6, < 1.0)
-    slimmer (12.1.0)
+    slimmer (13.0.0)
       activesupport
       json
       nokogiri (~> 1.7)
@@ -382,7 +382,7 @@ DEPENDENCIES
   rails-i18n (~> 5.1.1)
   rails_translation_manager (~> 0.0.2)
   sass-rails (~> 5.0.6)
-  slimmer (~> 12.1.0)
+  slimmer (~> 13.0.0)
   uglifier (>= 1.3.0)
   web-console (~> 3.6)
   webmock (~> 3.4.2)
@@ -392,4 +392,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::GovukComponents
-
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -79,7 +79,7 @@
   <div class="column-two-thirds">
 
     <div class="govspeak-wrapper">
-      <%= render 'govuk_component/govspeak', content: @content_item.body.html_safe %>
+      <%= render 'govuk_publishing_components/components/govspeak', content: @content_item.body.html_safe %>
     </div>
 
     <div class="change-history" data-module="toggle">

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class ContentItemsControllerTest < ActionController::TestCase
-  include Slimmer::TestHelpers::GovukComponents
-
   test "routing handles translated content paths" do
     translated_path = 'government/case-studies/allez.fr'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,18 +5,12 @@ require 'webmock/minitest'
 require 'capybara/rails'
 require 'capybara/poltergeist'
 require 'slimmer/test'
-require 'slimmer/test_helpers/govuk_components'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |file| require file }
 
 class ActiveSupport::TestCase
   include GovukContentSchemaExamples
   include DraftStackExamples
-  include Slimmer::TestHelpers::GovukComponents
-
-  def setup
-    stub_shared_component_locales
-  end
 end
 
 # Note: This is so that slimmer is skipped, preventing network requests for
@@ -33,7 +27,6 @@ Capybara.javascript_driver = :poltergeist
 class ActionDispatch::IntegrationTest
   # Make the Capybara DSL available in all integration tests
   include Capybara::DSL
-  include Slimmer::TestHelpers::GovukComponents
 
   # When running JS tests with Capybara the app and the test runner run
   # in separate threads. Capybara shoots off http://localhost:<some port>/__identify__
@@ -43,10 +36,6 @@ class ActionDispatch::IntegrationTest
   # run a lot of services that might give us a false positive.
   driver_requests = %r{/__identify__$}
   WebMock.disable_net_connect! allow: driver_requests
-
-  def setup
-    stub_shared_component_locales
-  end
 
   def using_javascript_driver
     begin


### PR DESCRIPTION
Because we're now no longer using components from Static, we can upgrade slimmer and remove usage of Slimmer::GovukComponents.

https://trello.com/c/ZMVwIyj5