### PR TITLE
Remove H1 from title

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
 </head>
 <body<% if content_for?(:body_classes) %> class="<%= content_for(:body_classes) %>"<% end %>>
   <div class="slimmer-inside-header">
-      <h1 class="header-title"><%= content_for(:header_title) || "Service Manual" %></h1>
+      <span class="header-title"><%= content_for(:header_title) || "Service Manual" %></span>
   </div>
 
   <div id="wrapper" class="<%= wrapper_class %>">


### PR DESCRIPTION
There should only be one H1 on the page, and the H1 should be the title of the page rather than the title of the product. For that reason, this replaces the H1 in the header with a span.