### PR TITLE
[DO NOT MERGE] Rename service standard

### DIFF
--- a/app/views/content_items/homepage.html.erb
+++ b/app/views/content_items/homepage.html.erb
@@ -13,7 +13,7 @@
         <h1 class="hero__title">Service Manual</h1>
 
         <p class="hero__description">
-          Helping government teams create and run great digital services that meet the <%= link_to 'Service Standard', '/service-manual/service-standard' %>.
+          Helping teams to create and run great public services that meet the <%= link_to 'Service Standard', '/service-manual/service-standard' %>.
         </p>
 
         <div class="hero__search search">
@@ -53,7 +53,7 @@
     <div class="column-half">
       <div class="panel">
         <h2 class="panel__title">The Service Standard</h2>
-        <p class="panel__description">The <%= link_to 'Service Standard', '/service-manual/service-standard' %> provides the principles of building a good digital service. This manual explains what teams can do to build great digital services that will meet the standard.</p>
+        <p class="panel__description">The <%= link_to 'Service Standard', '/service-manual/service-standard' %> provides the principles of building a good service. This manual explains what teams can do to build great services that will meet the standard.</p>
       </div>
     </div>
 

--- a/app/views/content_items/homepage.html.erb
+++ b/app/views/content_items/homepage.html.erb
@@ -13,7 +13,7 @@
         <h1 class="hero__title">Service Manual</h1>
 
         <p class="hero__description">
-          Helping government teams create and run great digital services that meet the <%= link_to 'Digital Service Standard', '/service-manual/service-standard' %>.
+          Helping government teams create and run great digital services that meet the <%= link_to 'Service Standard', '/service-manual/service-standard' %>.
         </p>
 
         <div class="hero__search search">
@@ -52,8 +52,8 @@
   <div class="grid-row">
     <div class="column-half">
       <div class="panel">
-        <h2 class="panel__title">The Digital Service Standard</h2>
-        <p class="panel__description">The <%= link_to 'Digital Service Standard', '/service-manual/service-standard' %> provides the principles of building a good digital service. This manual explains what teams can do to build great digital services that will meet the standard.</p>
+        <h2 class="panel__title">The Service Standard</h2>
+        <p class="panel__description">The <%= link_to 'Service Standard', '/service-manual/service-standard' %> provides the principles of building a good digital service. This manual explains what teams can do to build great digital services that will meet the standard.</p>
       </div>
     </div>
 

--- a/app/views/content_items/service_standard.html.erb
+++ b/app/views/content_items/service_standard.html.erb
@@ -50,7 +50,7 @@
         <h2 class="related-item__title" id="related-subscriptions">
           Get notifications
         </h2>
-        <p class="related-item__description">When any points in the Digital Service Standard are updated
+        <p class="related-item__description">When any points in the Service Standard are updated
           <%= link_to "email", @content_item.email_alert_signup_link, class: 'related-item__email-link' %>
         </p>
       </div>
@@ -62,7 +62,7 @@
           Download the poster
         </h2>
         <p class="related-item__description">
-          <%= link_to "Download and print your own Digital Service Standard poster", @content_item.poster_url %>
+          <%= link_to "Download and print your own Service Standard poster", @content_item.poster_url %>
         </p>
       </div>
     <% end %>

--- a/app/views/content_items/service_standard.html.erb
+++ b/app/views/content_items/service_standard.html.erb
@@ -16,9 +16,9 @@
       <p class="page-header__summary">
         <%= @content_item.content_item["description"] %>
       </p>
-      <p class="page-header__intro">
-        <%= @content_item.content_item["details"]["body"] %>
-      </p>
+      <div class="page-header__intro">
+        <%= @content_item.content_item["details"]["body"].html_safe %>
+      </div>
     </div>
   </div>
 </div>

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -5,8 +5,8 @@ class HomepageTest < ActionDispatch::IntegrationTest
     setup_and_visit_example('service_manual_homepage', 'service_manual_homepage')
 
     assert page.has_content? <<-TEXT
-      Helping government teams create and run
-      great digital services that meet the Service Standard.
+      Helping teams to create and run great public services that meet the
+      Service Standard.
     TEXT
   end
 
@@ -31,9 +31,9 @@ class HomepageTest < ActionDispatch::IntegrationTest
     setup_and_visit_example('service_manual_homepage', 'service_manual_homepage')
 
     assert page.has_content? <<-TEXT
-      The Service Standard provides the principles of building a good
-      digital service. This manual explains what teams can do to build great
-      digital services that will meet the standard.
+      The Service Standard provides the principles of building a good service.
+      This manual explains what teams can do to build great services that will
+      meet the standard.
     TEXT
 
     assert page.has_link? 'Service Standard', href: '/service-manual/service-standard'

--- a/test/integration/homepage_test.rb
+++ b/test/integration/homepage_test.rb
@@ -6,7 +6,7 @@ class HomepageTest < ActionDispatch::IntegrationTest
 
     assert page.has_content? <<-TEXT
       Helping government teams create and run
-      great digital services that meet the Digital Service Standard.
+      great digital services that meet the Service Standard.
     TEXT
   end
 
@@ -27,16 +27,16 @@ class HomepageTest < ActionDispatch::IntegrationTest
     assert page.has_link? 'Agile delivery', href: '/service-manual/agile-delivery'
   end
 
-  test 'the homepage includes a link to the digital service standard' do
+  test 'the homepage includes a link to the service standard' do
     setup_and_visit_example('service_manual_homepage', 'service_manual_homepage')
 
     assert page.has_content? <<-TEXT
-      The Digital Service Standard provides the principles of building a good
+      The Service Standard provides the principles of building a good
       digital service. This manual explains what teams can do to build great
       digital services that will meet the standard.
     TEXT
 
-    assert page.has_link? 'Digital Service Standard', href: '/service-manual/service-standard'
+    assert page.has_link? 'Service Standard', href: '/service-manual/service-standard'
   end
 
   test 'the homepage includes a link to the communities of practise' do

--- a/test/integration/service_standard_test.rb
+++ b/test/integration/service_standard_test.rb
@@ -2,10 +2,18 @@ require 'test_helper'
 
 class ServiceStandardTest < ActionDispatch::IntegrationTest
   test "service standard page has a title, summary and intro" do
-    setup_and_visit_example('service_manual_service_standard', 'service_manual_service_standard')
+    setup_and_visit_example(
+      'service_manual_service_standard',
+      'service_manual_service_standard',
+      title: "Service Standard",
+      description: "The Service Standard is a set of 14 criteria.",
+      details: {
+        body: "All public facing transactional services must meet the standard."
+      }
+    )
 
-    assert page.has_css?(".page-header__title", text: "Digital Service Standard"), "No title found"
-    assert page.has_css?(".page-header__summary", text: "The Digital Service Standard is a set of 18 criteria"), "No description found"
+    assert page.has_css?(".page-header__title", text: "Service Standard"), "No title found"
+    assert page.has_css?(".page-header__summary", text: "The Service Standard is a set of 14 criteria"), "No description found"
     assert page.has_css?(".page-header__intro", text: "All public facing transactional services must meet the standard."), "No body found"
   end
 

--- a/test/integration/service_toolkit_test.rb
+++ b/test/integration/service_toolkit_test.rb
@@ -88,9 +88,6 @@ class ServiceToolkitTest < ActionDispatch::IntegrationTest
     within(the_first_collection) do
       assert page.has_link? "Service Standard",
                             href: 'https://www.gov.uk/service-manual/service-standard'
-
-      assert page.has_link? "Service Manual",
-                            href: 'https://www.gov.uk/service-manual'
     end
 
     within(the_second_collection) do

--- a/test/integration/service_toolkit_test.rb
+++ b/test/integration/service_toolkit_test.rb
@@ -4,7 +4,7 @@ class ServiceToolkitTest < ActionDispatch::IntegrationTest
   test 'the service toolkit can be visited' do
     setup_and_visit_example('service_manual_service_toolkit', 'service_manual_service_toolkit')
 
-    assert page.has_title? "Service Toolkit"
+    assert page.has_title? 'Service Toolkit'
   end
 
   test 'the service toolkit does not include the new style feedback form' do
@@ -26,18 +26,18 @@ class ServiceToolkitTest < ActionDispatch::IntegrationTest
   test 'the homepage includes both collections' do
     setup_and_visit_example('service_manual_service_toolkit', 'service_manual_service_toolkit')
 
-    assert_equal 2, collections.length, "Expected to find 2 collections"
+    assert_equal 2, collections.length, 'Expected to find 2 collections'
   end
 
   test 'the homepage includes the titles for both collections' do
     setup_and_visit_example('service_manual_service_toolkit', 'service_manual_service_toolkit')
 
     within(the_first_collection) do
-      assert page.has_content? "Standards"
+      assert page.has_content? 'Standards'
     end
 
     within(the_second_collection) do
-      assert page.has_content? "Buying"
+      assert page.has_content? 'Buying'
     end
   end
 
@@ -45,19 +45,48 @@ class ServiceToolkitTest < ActionDispatch::IntegrationTest
     setup_and_visit_example('service_manual_service_toolkit', 'service_manual_service_toolkit')
 
     within(the_first_collection) do
-      assert page.has_content? "Meet the standards for government services"
+      assert page.has_content? 'Meet the standards for government services'
     end
 
     within(the_second_collection) do
-      assert page.has_content? "Extra skills, people and technology to help build your service"
+      assert page.has_content? 'Extra skills, people and technology to help build your service'
     end
   end
 
-  test 'the homepage includes the links from both collections' do
-    setup_and_visit_example('service_manual_service_toolkit', 'service_manual_service_toolkit')
+  test 'the homepage includes the links from all collections' do
+    setup_and_visit_example(
+      'service_manual_service_toolkit',
+      'service_manual_service_toolkit',
+      details: {
+        collections: [
+          {
+            title: 'Standards',
+            description: 'Meet the standards for government services',
+            links: [
+              {
+                title: 'Service Standard',
+                url: 'https://www.gov.uk/service-manual/service-standard',
+                description: ''
+              }
+            ]
+          },
+          {
+            title: 'Buying',
+            description: 'Skills and technology for building digital services',
+            links: [
+              {
+                title: 'Digital Marketplace',
+                url: 'https://www.gov.uk/digital-marketplace',
+                description: ''
+              }
+            ]
+          }
+        ]
+      }
+    )
 
     within(the_first_collection) do
-      assert page.has_link? "The Digital Service Standard",
+      assert page.has_link? "Service Standard",
                             href: 'https://www.gov.uk/service-manual/service-standard'
 
       assert page.has_link? "Service Manual",

--- a/test/presenters/guide_presenter_test.rb
+++ b/test/presenters/guide_presenter_test.rb
@@ -44,7 +44,7 @@ class GuidePresenterTest < ActiveSupport::TestCase
 
     presenter = GuidePresenter.new(JSON.parse(example))
 
-    assert presenter.category_title, "The Digital Service Standard"
+    assert presenter.category_title, "The Service Standard"
   end
 
   test "#category_title can be empty" do

--- a/test/presenters/service_standard_presenter_test.rb
+++ b/test/presenters/service_standard_presenter_test.rb
@@ -51,13 +51,13 @@ class ServiceStandardPresenterTest < ActiveSupport::TestCase
 
   test "#breadcrumbs contains a link to the service manual root" do
     content_item_hash = {
-      "title" => "Digital Service Standard"
+      "title" => "Service Standard"
     }
 
     assert ServiceStandardPresenter.new(content_item_hash).breadcrumbs,
            [
              { title: "Service manual", url: "/service-manual" },
-             { title: "Digital Service Standard" },
+             { title: "Service Standard" },
            ]
   end
 


### PR DESCRIPTION
**DO NOT MERGE WITHOUT CONFIRMING WITH SERVICE MANUAL TEAM** – the Service Standard's name is not changing yet.

Related:

- https://github.com/alphagov/service-manual-publisher/pull/530
- https://github.com/alphagov/govuk-content-schemas/pull/812