### PR TITLE
Don't send User Agent in contact form

### DIFF
--- a/app/views/shared/_improve_this_page.html.erb
+++ b/app/views/shared/_improve_this_page.html.erb
@@ -32,7 +32,6 @@
           <div class="js-errors"></div>
           <form>
             <input type="hidden" name="url" value="<%= request.original_url -%>">
-            <input type="hidden" name="user_agent" value="<%= request.user_agent -%>">
             <div class="form-group">
               <label class="form-label-bold" for="description-field">
                 How should we improve this page?

--- a/spec/javascripts/improve-this-page-spec.js
+++ b/spec/javascripts/improve-this-page-spec.js
@@ -14,7 +14,6 @@ describe("Improve this page", function () {
         '<div class="js-errors"></div>' +
         '<form>' +
           '<input type="hidden" name="url" value="http://example.com/path/to/page"></input>' +
-          '<input type="hidden" name="user_agent" value="Safari"></input>' +
           '<div class="form-group">' +
             '<label class="form-label-bold" for="description-field">' +
               'How should we improve this page?' +
@@ -280,8 +279,7 @@ describe("Improve this page", function () {
         url: ["http://example.com/path/to/page"],
         description: ["The background should be green."],
         name: ["Henry"],
-        email: ["henry@example.com"],
-        user_agent: ["Safari"]
+        email: ["henry@example.com"]
       });
     });
 
@@ -484,7 +482,7 @@ describe("Improve this page", function () {
 
     it("displays a generic error message", function () {
       expect($('.improve-this-page').html()).toContainText(
-        'Sorry, we’re unable to receive your message right now. ' + 
+        'Sorry, we’re unable to receive your message right now. ' +
         'If the problem persists, we have other ways for you to provide ' +
         'feedback on the contact page.'
       );


### PR DESCRIPTION
The "How should we improve this page?" currently sends the user agent of the request.

Like https://github.com/alphagov/govuk_publishing_components/pull/699, this is wrong because the page will be cached, so that any subsequent page requests will return the same HTML with the same form fields - and the previous request's user agent.

Because this feature has been broken for a number of years, we're removing it instead of fixing it. We think the reason the user agent was included in the first place was taken from GOV.UK. We've found no good reason to collect this information.