### PR TITLE
Load all scripts from govuk_publishing_components

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,6 @@
+//= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/all_components
+//
 // from govuk_frontend_toolkit and not delivered by static as part of
 // header-footer-only on deployed environments
 //= require govuk/stick-at-top-when-scrolling
@@ -5,7 +8,6 @@
 //
 //= require_tree ./govuk
 //= require_tree ./modules
-//= require govuk_publishing_components/components/feedback
 
 window.GOVUK.stickAtTopWhenScrolling.init();
 window.GOVUK.stopScrollingAtFooter.addEl($('.js-stick-at-top-when-scrolling'));


### PR DESCRIPTION
Scripts in govuk_publishing_components contain not only component-related scripts, but also polyfills and accessibility shims that should be included in every application.