### PR TITLE
Fix 'show all updates' link

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -82,7 +82,7 @@
       <%= render 'govuk_publishing_components/components/govspeak', content: @content_item.body.html_safe %>
     </div>
 
-    <div class="change-history" data-module="toggle">
+    <div class="change-history" data-module="gem-toggle">
       <div class="change-history__latest-change">
         <dl>
         <% if @content_item.content_owners.any? %>


### PR DESCRIPTION
- toggle js module seems to be initialised twice, fix is to use the gem-toggle (copy code) in the components gem instead
