### PR TITLE
Fix failing test when run in BST

### DIFF
--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -24,7 +24,7 @@ class GuideTest < ActionDispatch::IntegrationTest
   end
 
   test "shows the time it was published if it has been published" do
-    travel_to("2015-10-10") do
+    travel_to Time.zone.local(2015, 10, 10, 0, 0, 0) do
       setup_and_visit_example('service_manual_guide', 'service_manual_guide')
 
       within('.metadata') do


### PR DESCRIPTION
When `travel_to("2015-10-10")` is called from a test environment in British Summer Time then Time.now is reported as `2015-10-10 00:00:00 +0100` but the tests assume it’ll be `2015-10-10 00:00:00 +0000`.

This means that the time reported in '.metadata' is reported as 'about 15 hours ago' which means the test fails.

I assume that this isn’t being seen on CI because CI lives in UTC(?).