### PR TITLE
When feedback form is closed refocus on the control that opened it

### DIFF
--- a/app/assets/javascripts/modules/improve-this-page.js
+++ b/app/assets/javascripts/modules/improve-this-page.js
@@ -24,6 +24,7 @@
     this.$feedbackFormSubmitButton = that.$feedbackFormContainer.find('[type=submit]');
     this.$feedbackFormCloseButton = that.$feedbackFormContainer.find('.js-close-feedback-form');
     this.$prompt = $element.find('.js-prompt');
+    this.$refocus = this.$prompt;
 
     this.onPageIsUsefulButtonClicked = function (callback) {
       that.$pageIsUsefulButton.on('click', preventingDefault(callback));
@@ -66,6 +67,8 @@
 
       if (formIsVisible) {
         $('.form-control', that.$feedbackFormContainer).first().focus();
+      } else {
+        this.$refocus.focus();
       }
     }
 
@@ -80,6 +83,14 @@
 
     this.feedbackFormContainerTrackEventParams = function () {
       return that.getTrackEventParams(that.$feedbackFormContainer);
+    }
+
+    this.setPageIsNotUsefulFocus  = function (callback) {
+      this.$refocus = this.$pageIsNotUsefulButton;
+    }
+
+    this.setSomethingIsWrongFocus  = function (callback) {
+      this.$refocus = this.$somethingIsWrongButton;
     }
 
     this.pageIsUsefulTrackEventParams = function () {
@@ -243,6 +254,7 @@
       var handler = function () {
         that.trackEvent(view.pageIsNotUsefulTrackEventParams());
 
+        view.setPageIsNotUsefulFocus();
         view.toggleFeedbackForm();
       }
 
@@ -253,6 +265,7 @@
       var handler = function () {
         that.trackEvent(view.somethingIsWrongTrackEventParams());
 
+        view.setSomethingIsWrongFocus();
         view.toggleFeedbackForm();
       }
 
@@ -263,7 +276,6 @@
       var handler = function () {
         view.toggleFeedbackForm();
       }
-
       view.onFeedbackFormCloseButtonClicked(handler);
     }
 

--- a/app/assets/stylesheets/modules/_improve-this-page.scss
+++ b/app/assets/stylesheets/modules/_improve-this-page.scss
@@ -16,6 +16,10 @@
   a:visited {
     color: $white;
     display: inline-block;
+
+    &:focus {
+      color: $black;
+    }
   }
 
   &:focus {


### PR DESCRIPTION
Screenreaders lose focus at the point that the feedback form is closed,
this resets the focus to where they came from and ensures correct
contrast on the focused link.

This brings the feedback section of the page in line with the version used throughout most of GOV.Uk via the govuk_publishing_components gem