### PR TITLE
Add correct text to updates toggle on expanded

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -102,7 +102,7 @@
         </dl>
       </div>
     <% if @content_item.previous_changes.present? %>
-      <p><a href="#full-history" data-controls="full-history" data-expanded="false" role="button" aria-controls="full-history" aria-expanded="false">+ Show all page updates (<%= @content_item.previous_changes.length + 1 %>)</a></p>
+      <p><a href="#full-history" data-controls="full-history" data-toggled-text="- Hide all page updates (<%= @content_item.previous_changes.length + 1 %>)" data-expanded="false" role="button" aria-controls="full-history" aria-expanded="false">+ Show all page updates (<%= @content_item.previous_changes.length + 1 %>)</a></p>
       <ol id="full-history" class="change-history__past js-hidden" aria-live="polite" role="region">
       <% @content_item.previous_changes.each do |previous_change| %>
         <li>


### PR DESCRIPTION
Fixes: #118 

Before: 
<img width="386" alt="Screen Shot 2019-09-10 at 12 54 46" src="https://user-images.githubusercontent.com/3758555/64611863-4ff7b880-d3ca-11e9-9c5d-dc31cb629802.png">

After:
<img width="354" alt="Screen Shot 2019-09-10 at 12 54 56" src="https://user-images.githubusercontent.com/3758555/64611870-5423d600-d3ca-11e9-955c-d001730b3dc8.png">
