### PR TITLE
Add basic auth to Heroku apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,13 @@
   "name": "Service Manual Frontend",
   "repository": "https://github.com/alphagov/service-manual-frontend",
   "env": {
+    "BASIC_AUTH_USERNAME": {
+      "required": true
+    },
+    "BASIC_AUTH_PASSWORD": {
+      "required": true
+    },
+    "REQUIRE_BASIC_AUTH": "true",
     "GOVUK_APP_DOMAIN": {
       "value": "www.gov.uk"
     },

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,11 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  if ENV["BASIC_AUTH_USERNAME"]
+    http_basic_authenticate_with(
+      name: ENV.fetch("BASIC_AUTH_USERNAME"),
+      password: ENV.fetch("BASIC_AUTH_PASSWORD")
+    )
+  end
 end


### PR DESCRIPTION
Taken from https://github.com/alphagov/government-frontend/pull/1484 . The username and password have already been defined within Heroku.