### PR TITLE
[DO NOT MERGE] Remove govuk_frontend_toolkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby File.read(".ruby-version").strip
 gem "gds-api-adapters", "~> 61.0.0"
 gem "govuk_app_config", "~> 2.0"
 gem "govuk_elements_rails"
-gem "govuk_frontend_toolkit", "~> 8.2.0"
 gem "govuk_publishing_components", "~> 21.10.0"
 gem "plek", "3.0.0"
 gem "rails", "~> 5.2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       govuk_frontend_toolkit (>= 6.0.2)
       rails (>= 4.1.0)
       sass (>= 3.2.0)
-    govuk_frontend_toolkit (8.2.0)
+    govuk_frontend_toolkit (9.0.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_publishing_components (21.10.0)
@@ -355,7 +355,6 @@ DEPENDENCIES
   govuk-lint
   govuk_app_config (~> 2.0)
   govuk_elements_rails
-  govuk_frontend_toolkit (~> 8.2.0)
   govuk_publishing_components (~> 21.10.0)
   jasmine-rails
   listen (>= 3.0.5, < 3.3)

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -1,7 +1,4 @@
 // This is a manifest file only included in test environments
-// from govuk_frontend_toolkit
-//= require govuk/modules
-
 $(document).ready(function () {
   GOVUK.modules.start();
 });


### PR DESCRIPTION
## What
Remove `govuk_frontend_toolkit`. Wasn't really being used much these days anyway - only use seems to be for GOVUK modules code, which was already being included as part of the components gem.

## Why
C'est obsolète.

## Visual Changes
None.

## Pages to check

* https://govuk-service-manual-fr-pr-578.herokuapp.com/service-manual/
* https://govuk-service-manual-fr-pr-578.herokuapp.com/service-manual/helping-people-to-use-your-service
* https://govuk-service-manual-fr-pr-578.herokuapp.com/service-manual/design
* https://govuk-service-manual-fr-pr-578.herokuapp.com/service-manual/service-assessments
* https://govuk-service-manual-fr-pr-578.herokuapp.com/service-manual/service-standard
* https://govuk-service-manual-fr-pr-578.herokuapp.com/service-manual/service-standard/point-1-understand-user-needs
* https://govuk-service-manual-fr-pr-578.herokuapp.com/service-manual/communities
* https://govuk-service-manual-fr-pr-578.herokuapp.com/service-manual/communities/accessibility-community
