### PR TITLE
README: Remove old, dev VM 'how to run the app' instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,9 @@ This is a Ruby on Rails application that fetches documents from
 - [content-store](https://github.com/alphagov/content-store) - provides documents
 - [static](https://github.com/alphagov/static) - provides shared GOV.UK assets and templates.
 
-### Running the application
+## Development notes
 
-You can use [Bowler](https://github.com/JordanHatch/bowler) to automatically run
-the application and all of its dependencies. To do this, you'll need to check
-out the [development repository](https://github.gds/gds/development) where the
-`Pinfile` is located.
-
-```
-cd /var/govuk/development
-bowl service-manual-frontend
-```
-
-Alternatively, run `./startup.sh` in the `service-manual-frontend` directory.
-
-```
-cd /var/govuk/service-manual-frontend
-./startup.sh
-```
-
-The application runs on port `3122` by default. If you're using the GDS VM it'll
-be available at http://service-manual-frontend.dev.gov.uk.
-
-Note that the application *does not serve content at its root (/)* - the
+The application *does not serve content at its root (/)* - the
 homepage will be found at service-manual-frontend.dev.gov.uk/service-manual but
 only if the content item for the homepage exists in the content store.
 


### PR DESCRIPTION
## What

- These instructions referenced the deprecated GOV.UK Development VM, `bowler`, \*and\* `./startup.sh`.
- The new standard is [GOV.UK Docker](https://github.com/alphagov/govuk-docker).

## Why

- The instructions to run the service manual were out of date and potentially confusing for new people or external contributors.