### PR TITLE
Remove frontend toolkit from service manual frontend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby File.read(".ruby-version").strip
 gem "gds-api-adapters", "~> 61.0.0"
 gem "govuk_app_config", "~> 2.0"
 gem "govuk_elements_rails"
-gem "govuk_frontend_toolkit", "~> 8.2.0"
 gem "govuk_publishing_components", "~> 21.13.2"
 gem "plek", "3.0.0"
 gem "rails", "~> 5.2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,7 +355,6 @@ DEPENDENCIES
   govuk-lint
   govuk_app_config (~> 2.0)
   govuk_elements_rails
-  govuk_frontend_toolkit (~> 8.2.0)
   govuk_publishing_components (~> 21.13.2)
   jasmine-rails
   listen (>= 3.0.5, < 3.3)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,13 +1,5 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
 //
-// from govuk_frontend_toolkit and not delivered by static as part of
-// header-footer-only on deployed environments
-//= require govuk/stick-at-top-when-scrolling
-//= require govuk/stop-scrolling-at-footer
-//
 //= require_tree ./govuk
 //= require_tree ./modules
-
-window.GOVUK.stickAtTopWhenScrolling.init();
-window.GOVUK.stopScrollingAtFooter.addEl($('.js-stick-at-top-when-scrolling'));

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -1,7 +1,0 @@
-// This is a manifest file only included in test environments
-// from govuk_frontend_toolkit
-//= require govuk/modules
-
-$(document).ready(function () {
-  GOVUK.modules.start();
-});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,4 @@
 $govuk-compatibility-govuktemplate: true;
-$govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govukelements: true;
 
 @import "govuk_publishing_components/all_components";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,4 +22,5 @@ $govuk-compatibility-govukelements: true;
 @import "modules/panel";
 @import "modules/related-content";
 @import "modules/service-standard-point";
+@import "modules/sticky";
 @import "modules/typography";

--- a/app/assets/stylesheets/modules/_sticky.scss
+++ b/app/assets/stylesheets/modules/_sticky.scss
@@ -1,0 +1,6 @@
+.app-sticky-element {
+  @include govuk-media-query($from: tablet) {
+    position: sticky;
+    top: 0;
+  }
+}

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -48,10 +48,9 @@
   </div>
 
   <div class="govuk-grid-row" data-module="highlight-active-section-heading">
-    <div class="govuk-grid-column-one-third">
-
+    <div class="govuk-grid-column-one-third app-sticky-element">
       <!--  Page contents -->
-      <div class="page-contents js-page-contents js-stick-at-top-when-scrolling js-sticky-resize">
+      <div class="page-contents js-page-contents">
         <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-margin-top-3">Page contents:</h2>
         <ul class="govuk-list app-page-contents__list">
           <% @content_item.header_links.each do |header_link| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,6 @@
   <%= stylesheet_link_tag "print", media: "print" %>
 
   <%= javascript_include_tag "application" %>
-  <%= javascript_include_tag "start-modules" if Rails.env.test? %>
   <%= csrf_meta_tags %>
   <%= render "govuk_publishing_components/components/meta_tags", content_item: @content_item.content_item %>
   <%= yield(:extra_head) %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -19,4 +19,3 @@ Rails.application.config.assets.precompile += %w(
   application-ie8.css
   print.css
 )
-Rails.application.config.assets.precompile += %w(start-modules) if Rails.env.test?


### PR DESCRIPTION
## What
Remove govuk-frontend-toolkit from service-manual-frontend.

This involves only one noticeable change for users - on [guide pages](https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction) a script from toolkit was being used to simulate `position: sticky`. This has been removed (well, not removed, but not called from toolkit anymore) and replaced with actual `position: sticky`. 

Sticky is supported in all major browsers apart from IE, but the only difference is that the menu won't scroll with the page. Consensus among the FE devs is that it's not worth the effort of a polyfill (also I tried and there are several problems that make the code hacky, so best avoided).

## Why
Goodnight toolkit, well, it's time to go...

## Visual Changes
No visual changes other than the sticky menu.

## Pages to check

* https://govuk-service-manual-fr-pr-585.herokuapp.com/service-manual/
* https://govuk-service-manual-fr-pr-585.herokuapp.com/service-manual/helping-people-to-use-your-service
* https://govuk-service-manual-fr-pr-585.herokuapp.com/service-manual/design
* https://govuk-service-manual-fr-pr-585.herokuapp.com/service-manual/service-assessments
* https://govuk-service-manual-fr-pr-585.herokuapp.com/service-manual/service-standard
* https://govuk-service-manual-fr-pr-585.herokuapp.com/service-manual/service-standard/point-1-understand-user-needs
* https://govuk-service-manual-fr-pr-585.herokuapp.com/service-manual/communities
* https://govuk-service-manual-fr-pr-585.herokuapp.com/service-manual/communities/accessibility-community
