### PR TITLE
Allow new lines to show in change notes

### DIFF
--- a/app/assets/stylesheets/modules/_change-history.scss
+++ b/app/assets/stylesheets/modules/_change-history.scss
@@ -1,3 +1,4 @@
 .app-change-history__change-note {
   color: $govuk-secondary-text-colour;
+  white-space: pre-line;
 }

--- a/app/views/shared/_change_history.html.erb
+++ b/app/views/shared/_change_history.html.erb
@@ -8,5 +8,5 @@
   <%= l time, format: :short_ordinal %>
 </time>
 <p class="govuk-body-s app-change-history__change-note govuk-!-width-two-thirds">
-  <%= change.note %>
+  <%= change.note.strip %>
 </p>


### PR DESCRIPTION
## What
This change allows change notes to have multiple lines. It also strips any leading or trailing white space from change notes.

## Why
Currently change notes are displayed on a single line, which can make certain larger changes hard to read. 

[trello](https://trello.com/c/rdNti5Hh/1670-5-investigate-and-fix-allowing-line-breaks-in-change-notes)
## Visual Changes
Before:
<img width="468" alt="Screenshot 2020-01-15 at 13 23 29" src="https://user-images.githubusercontent.com/13475227/72437309-5d6ae800-379a-11ea-9382-a69b3ab551b8.png">

After:
<img width="434" alt="Screenshot 2020-01-15 at 13 24 04" src="https://user-images.githubusercontent.com/13475227/72437314-6065d880-379a-11ea-994f-8a2e11672222.png">

<!--
## Pages to check

* https://govuk-service-manual-fr-pr-[ADD-PR-NUMBER-HERE].herokuapp.com/service-manual/
* https://govuk-service-manual-fr-pr-[ADD-PR-NUMBER-HERE].herokuapp.com/service-manual/helping-people-to-use-your-service
* https://govuk-service-manual-fr-pr-[ADD-PR-NUMBER-HERE].herokuapp.com/service-manual/design
* https://govuk-service-manual-fr-pr-[ADD-PR-NUMBER-HERE].herokuapp.com/service-manual/service-assessments
* https://govuk-service-manual-fr-pr-[ADD-PR-NUMBER-HERE].herokuapp.com/service-manual/service-standard
* https://govuk-service-manual-fr-pr-[ADD-PR-NUMBER-HERE].herokuapp.com/service-manual/service-standard/point-1-understand-user-needs
* https://govuk-service-manual-fr-pr-[ADD-PR-NUMBER-HERE].herokuapp.com/service-manual/communities
* https://govuk-service-manual-fr-pr-[ADD-PR-NUMBER-HERE].herokuapp.com/service-manual/communities/accessibility-community

-->
