### PR TITLE
Turn off legacy colour palette to update to new colours

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-compatibility-govukelements: true;
+$govuk-use-legacy-palette: false;
 
 @import "govuk_publishing_components/all_components";
 @import "mixins/margins";


### PR DESCRIPTION
## What
The legacy palette flag (`$govuk-use-legacy-palette`) is set to false to turn on the new colours.

## Why
Part of the process to make GOV.UK more accessible - card is https://trello.com/c/Dd49EiEv/122-switch-to-new-colours-in-service-manual-frontend

## Visual Changes
Oh so many. 

Any yellow and blue should change from:
![image](https://user-images.githubusercontent.com/1732331/72531084-abe6b800-3868-11ea-84ac-f158aaa83402.png)

to:
![image](https://user-images.githubusercontent.com/1732331/72531116-b903a700-3868-11ea-91bd-1b196210baff.png)

## Pages to check

* https://govuk-service-manual-fr-pr-616.herokuapp.com/service-manual/
* https://govuk-service-manual-fr-pr-616.herokuapp.com/service-manual/helping-people-to-use-your-service
* https://govuk-service-manual-fr-pr-616.herokuapp.com/service-manual/design
* https://govuk-service-manual-fr-pr-616.herokuapp.com/service-manual/service-assessments
* https://govuk-service-manual-fr-pr-616.herokuapp.com/service-manual/service-standard
* https://govuk-service-manual-fr-pr-616.herokuapp.com/service-manual/service-standard/point-1-understand-user-needs
* https://govuk-service-manual-fr-pr-616.herokuapp.com/service-manual/communities
* https://govuk-service-manual-fr-pr-616.herokuapp.com/service-manual/communities/accessibility-community

