### PR TITLE
Remove unused dependency on govuk_elements_rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby File.read(".ruby-version").strip
 
 gem "gds-api-adapters", "~> 63.3.0"
 gem "govuk_app_config", "~> 2.0"
-gem "govuk_elements_rails"
 gem "govuk_publishing_components", "~> 21.21.3"
 gem "plek", "3.0.0"
 gem "rails", "~> 5.2.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,13 +107,6 @@ GEM
       sentry-raven (>= 2.7.1, < 2.14.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_elements_rails (3.1.3)
-      govuk_frontend_toolkit (>= 6.0.2)
-      rails (>= 4.1.0)
-      sass (>= 3.2.0)
-    govuk_frontend_toolkit (8.2.0)
-      railties (>= 3.1.0)
-      sass (>= 3.2.0)
     govuk_publishing_components (21.21.3)
       gds-api-adapters
       govuk_app_config
@@ -354,7 +347,6 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint
   govuk_app_config (~> 2.0)
-  govuk_elements_rails
   govuk_publishing_components (~> 21.21.3)
   jasmine-rails
   listen (>= 3.0.5, < 3.3)


### PR DESCRIPTION
## What
Remove dependency on `govuk_elements_rails`

## Why
Because it is not being used

## Visual Changes
None expected 🤞 

## Pages to check

* https://govuk-service-manual-fr-pr-623.herokuapp.com/service-manual/
* https://govuk-service-manual-fr-pr-623.herokuapp.com/service-manual/helping-people-to-use-your-service
* https://govuk-service-manual-fr-pr-623.herokuapp.com/service-manual/design
* https://govuk-service-manual-fr-pr-623.herokuapp.com/service-manual/service-assessments
* https://govuk-service-manual-fr-pr-623.herokuapp.com/service-manual/service-standard
* https://govuk-service-manual-fr-pr-623.herokuapp.com/service-manual/service-standard/point-1-understand-user-needs
* https://govuk-service-manual-fr-pr-623.herokuapp.com/service-manual/communities
* https://govuk-service-manual-fr-pr-623.herokuapp.com/service-manual/communities/accessibility-community
