### PR TITLE
Change Service Manual to not use 'breadcrumb for current page' option

### DIFF
--- a/app/presenters/guide_presenter.rb
+++ b/app/presenters/guide_presenter.rb
@@ -24,7 +24,6 @@ class GuidePresenter < ContentItemPresenter
   def breadcrumbs
     crumbs = [{ title: "Service manual", url: "/service-manual" }]
     crumbs << { title: category["title"], url: category["base_path"] } if category
-    crumbs << { title: content_item["title"] }
     crumbs
   end
 

--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -13,7 +13,6 @@ class ServiceStandardPresenter < ContentItemPresenter
   def breadcrumbs
     [
       { title: "Service manual", url: "/service-manual" },
-      { title: title },
     ]
   end
 

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -7,7 +7,7 @@ class TopicPresenter < ContentItemPresenter
   end
 
   def breadcrumbs
-    parent_breadcrumbs << topic_breadcrumb
+    parent_breadcrumbs
   end
 
   def groups
@@ -111,9 +111,5 @@ private
         url: "/service-manual",
       },
     ]
-  end
-
-  def topic_breadcrumb
-    { title: title }
   end
 end

--- a/test/presenters/guide_presenter_test.rb
+++ b/test/presenters/guide_presenter_test.rb
@@ -17,7 +17,6 @@ class GuidePresenterTest < ActiveSupport::TestCase
     assert_equal [
                    { title: "Service manual", url: "/service-manual" },
                    { title: "Agile", url: "/service-manual/agile" },
-                   { title: "Agile Delivery" },
                  ],
                  guide.breadcrumbs
   end
@@ -26,7 +25,6 @@ class GuidePresenterTest < ActiveSupport::TestCase
     presented_guide = presented_guide("links" => {})
     assert_equal [
                    { title: "Service manual", url: "/service-manual" },
-                   { title: "Agile Delivery" },
                  ],
                  presented_guide.breadcrumbs
   end

--- a/test/presenters/service_standard_presenter_test.rb
+++ b/test/presenters/service_standard_presenter_test.rb
@@ -57,7 +57,6 @@ class ServiceStandardPresenterTest < ActiveSupport::TestCase
     assert ServiceStandardPresenter.new(content_item_hash).breadcrumbs,
            [
              { title: "Service manual", url: "/service-manual" },
-             { title: "Service Standard" },
            ]
   end
 

--- a/test/presenters/topic_presenter_test.rb
+++ b/test/presenters/topic_presenter_test.rb
@@ -51,12 +51,11 @@ class TopicPresenterTest < ActiveSupport::TestCase
     assert_equal "/service-manual/agile-community", agile_community.href
   end
 
-  test "#breadcrumbs links to the root path and references itself" do
-    topic = presented_topic(title: "Hello")
+  test "#breadcrumbs links to the root path" do
+    topic = presented_topic
 
     expected_breadcrumbs = [
       { title: "Service manual", url: "/service-manual" },
-      { title: "Hello" },
     ]
     assert_equal expected_breadcrumbs, topic.breadcrumbs
   end


### PR DESCRIPTION
Updated Service manual breadcrumb to not display the last item without a url. This is as per the updated breadcrumb design where the last item should be current pages parent

For reference:
https://docs.google.com/document/d/1OFG1Ln6VeCR_bc0qmUtRwMJU62Ljw4F3HO6hq2yloXk

Trello card:
https://trello.com/c/VorvrMfy/39-change-it-so-service-manual-doesnt-use-breadcrumb-for-current-page-option

## What
- removed guide item with no url
- remove topic title with no url
- removed topic breadcrumb with no url
- updated tests to remove no url last item

## Why
Consistent breadcrumb functionality to show parent as the last item and not the current documents title

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

![service manual breadcrumb](https://user-images.githubusercontent.com/54625020/75032831-69388100-54a1-11ea-8621-afc73f65fbc0.png)


<!--
## Pages to check

* /service-manual/
* /service-manual/helping-people-to-use-your-service
* /service-manual/design
* /service-manual/service-assessments
*/service-manual/service-standard
* /service-manual/service-standard/point-1-understand-user-needs
* /service-manual/communities
* /service-manual/communities/accessibility-community

-->
