### PR TITLE
Collapse breadcrumbs on mobile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby File.read(".ruby-version").strip
 
 gem "gds-api-adapters", "~> 63.5.1"
 gem "govuk_app_config", "~> 2.0"
-gem "govuk_publishing_components", "~> 21.26.1"
+gem "govuk_publishing_components", "~> 21.27.0"
 gem "plek", "3.0.0"
 gem "rails", "~> 5.2.4"
 gem "rails-i18n", "~> 5.1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       sentry-raven (>= 2.7.1, < 2.14.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_publishing_components (21.26.1)
+    govuk_publishing_components (21.27.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -347,7 +347,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint
   govuk_app_config (~> 2.0)
-  govuk_publishing_components (~> 21.26.1)
+  govuk_publishing_components (~> 21.27.0)
   jasmine-rails
   listen (>= 3.0.5, < 3.3)
   phantomjs (~> 2.1, >= 2.1.1.0)

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -10,7 +10,10 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= render "govuk_publishing_components/components/breadcrumbs", breadcrumbs: @content_item.breadcrumbs %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: @content_item.breadcrumbs,
+    collapse_on_mobile: true
+  } %>
 
   <!-- Page title and contact -->
   <div class="govuk-grid-row">

--- a/app/views/content_items/service_standard.html.erb
+++ b/app/views/content_items/service_standard.html.erb
@@ -5,7 +5,10 @@
   <%= render 'shared/custom_phase_message', phase: @content_item.phase %>
 <% end %>
 <div class="govuk-width-container">
-  <%= render "govuk_publishing_components/components/breadcrumbs", breadcrumbs: @content_item.breadcrumbs %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: @content_item.breadcrumbs,
+    collapse_on_mobile: true
+  } %>
 
   <!-- Page title and contact -->
   <div class="govuk-grid-row">

--- a/app/views/content_items/topic.html.erb
+++ b/app/views/content_items/topic.html.erb
@@ -6,7 +6,10 @@
 <% end %>
 <div class="govuk-width-container">
 
-  <%= render "govuk_publishing_components/components/breadcrumbs", breadcrumbs: @content_item.breadcrumbs %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: @content_item.breadcrumbs,
+    collapse_on_mobile: true
+  } %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -45,7 +45,7 @@ class GuideTest < ActionDispatch::IntegrationTest
   test "the breadcrumb contains the topic" do
     setup_and_visit_example("service_manual_guide", "service_manual_guide")
 
-    within(".gem-c-breadcrumbs") do
+    within(".gem-c-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile") do
       assert page.has_link?("Service manual")
       assert page.has_link?("Agile")
     end


### PR DESCRIPTION
## What
Add `collapse_on_mobile` flag to breadcrumbs

## Why
We want breadcrumbs to be consistent across GOVUK

## Pages to check

* https://govuk-servic-collapse-b-1rjnmt.herokuapp.com/service-manual/
* https://govuk-servic-collapse-b-1rjnmt.herokuapp.com/service-manual/helping-people-to-use-your-service
* https://govuk-servic-collapse-b-1rjnmt.herokuapp.com/service-manual/design
* https://govuk-servic-collapse-b-1rjnmt.herokuapp.com/service-manual/service-assessments
* https://govuk-servic-collapse-b-1rjnmt.herokuapp.com/service-manual/service-standard
* https://govuk-servic-collapse-b-1rjnmt.herokuapp.com/service-manual/service-standard/point-1-understand-user-needs
* https://govuk-servic-collapse-b-1rjnmt.herokuapp.com/service-manual/communities
* https://govuk-servic-collapse-b-1rjnmt.herokuapp.com/service-manual/communities/accessibility-community
