### PR TITLE
Use `rubocop-govuk` instead of `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,10 @@ Lint/AmbiguousBlockAssociation:
 
 Lint/UriEscapeUnescape:
   Enabled: false
+
+# These `.to_time` conversions were obviously done for a reason back
+# in the day. I'm not confident enough in RuboCop's autocorrections
+# to change the behaviour by removing them in files like
+# `app/presenters/guide_presenter.rb`.
+Rails/Date:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml
+
 Lint/AmbiguousBlockAssociation:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "slimmer", "~> 13.2.0"
 gem "uglifier", ">= 1.3.0"
 
 group :development, :test do
-  gem "govuk-lint"
+  gem "rubocop-govuk"
   gem "jasmine-rails"
   gem "phantomjs", "~> 2.1", ">= 2.1.1.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,9 @@ gem "slimmer", "~> 13.2.0"
 gem "uglifier", ">= 1.3.0"
 
 group :development, :test do
-  gem "rubocop-govuk"
   gem "jasmine-rails"
   gem "phantomjs", "~> 2.1", ">= 2.1.1.0"
+  gem "rubocop-govuk"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,11 +97,6 @@ GEM
       activesupport (>= 4.2.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.3)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.14.0)
@@ -170,7 +165,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     null_logger (0.0.1)
     parallel (1.18.0)
-    parser (2.6.5.0)
+    parser (2.7.0.4)
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     plek (3.0.0)
@@ -239,17 +234,21 @@ GEM
       netrc (~> 0.8)
     robotex (1.0.0)
     rouge (3.16.0)
-    rubocop (0.76.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.3.2)
+    rubocop-govuk (2.0.0)
+      rubocop (= 0.77)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rubyzip (1.3.0)
@@ -273,8 +272,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -306,7 +303,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
     unicorn (5.5.3)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -345,7 +342,6 @@ DEPENDENCIES
   capybara
   gds-api-adapters (~> 63.5.1)
   govuk-content-schema-test-helpers (~> 1.6)
-  govuk-lint
   govuk_app_config (~> 2.0)
   govuk_publishing_components (~> 21.27.1)
   jasmine-rails
@@ -358,6 +354,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-i18n (~> 5.1.3)
   rails_translation_manager (~> 0.1.0)
+  rubocop-govuk
   sass-rails (~> 5.0.6)
   slimmer (~> 13.2.0)
   uglifier (>= 1.3.0)

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -100,6 +100,6 @@ private
   end
 
   def error_403(exception)
-    render body: exception.message, status: 403
+    render body: exception.message, status: :forbidden
   end
 end

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -55,7 +55,7 @@ class GuideTest < ActionDispatch::IntegrationTest
     setup_and_visit_example("service_manual_guide", "service_manual_guide_community")
 
     within(".gem-c-metadata") do
-      refute page.has_content?("Published by")
+      assert_not page.has_content?("Published by")
     end
   end
 
@@ -70,7 +70,7 @@ class GuideTest < ActionDispatch::IntegrationTest
   test "does not display the description for a normal guide" do
     setup_and_visit_example("service_manual_guide", "service_manual_guide")
 
-    refute page.has_css?(".app-page-header__summary")
+    assert_not page.has_css?(".app-page-header__summary")
   end
 
   test "displays a link to give feedback" do
@@ -115,8 +115,8 @@ class GuideTest < ActionDispatch::IntegrationTest
                               ],
                             })
 
-    refute page.has_content? "Show all page updates"
-    refute page.has_css? ".app-change-history__past"
+    assert_not page.has_content? "Show all page updates"
+    assert_not page.has_css? ".app-change-history__past"
   end
 
   test "omits the latest change and previous change if the guide has no history" do
@@ -125,8 +125,8 @@ class GuideTest < ActionDispatch::IntegrationTest
                               "change_history" => [],
                             })
 
-    refute page.has_content? "Last update:"
-    refute page.has_content? "Show all page updates"
-    refute page.has_css? ".app-change-history__past"
+    assert_not page.has_content? "Last update:"
+    assert_not page.has_content? "Show all page updates"
+    assert_not page.has_css? ".app-change-history__past"
   end
 end

--- a/test/integration/phase_label_test.rb
+++ b/test/integration/phase_label_test.rb
@@ -45,6 +45,6 @@ class PhaseLabelTest < ActionDispatch::IntegrationTest
 
     visit guide["base_path"]
 
-    refute page.has_content?("Complete our quick 5-question survey")
+    assert_not page.has_content?("Complete our quick 5-question survey")
   end
 end

--- a/test/integration/service_toolkit_test.rb
+++ b/test/integration/service_toolkit_test.rb
@@ -11,7 +11,7 @@ class ServiceToolkitTest < ActionDispatch::IntegrationTest
     setup_and_visit_example("service_manual_service_toolkit", "service_manual_service_toolkit")
 
     assert_not page.has_css?(".improve-this-page"),
-           "Improve this page component should not be present on the page"
+               "Improve this page component should not be present on the page"
   end
 
   test "the service toolkit displays the introductory hero" do

--- a/test/integration/service_toolkit_test.rb
+++ b/test/integration/service_toolkit_test.rb
@@ -10,7 +10,7 @@ class ServiceToolkitTest < ActionDispatch::IntegrationTest
   test "the service toolkit does not include the new style feedback form" do
     setup_and_visit_example("service_manual_service_toolkit", "service_manual_service_toolkit")
 
-    refute page.has_css?(".improve-this-page"),
+    assert_not page.has_css?(".improve-this-page"),
            "Improve this page component should not be present on the page"
   end
 

--- a/test/integration/topic_test.rb
+++ b/test/integration/topic_test.rb
@@ -26,7 +26,7 @@ class TopicTest < ActionDispatch::IntegrationTest
 
     visit "/service-manual/test-topic"
 
-    refute page.has_css?('meta[name="description"]', visible: false)
+    assert_not page.has_css?('meta[name="description"]', visible: false)
   end
 
   test "it lists communities in the sidebar" do

--- a/test/presenters/guide_presenter_test.rb
+++ b/test/presenters/guide_presenter_test.rb
@@ -70,7 +70,7 @@ class GuidePresenterTest < ActiveSupport::TestCase
   end
 
   test "#show_description? is false if not set" do
-    refute GuidePresenter.new({}).show_description?
+    assert_not GuidePresenter.new({}).show_description?
   end
 
   test "#public_updated_at returns a time" do

--- a/test/presenters/topic_presenter/topic_group_test.rb
+++ b/test/presenters/topic_presenter/topic_group_test.rb
@@ -41,6 +41,6 @@ class TopicPresenter::TopicGroupTest < ActiveSupport::TestCase
     linked_items = []
     group = described_class.new(group_data, linked_items)
 
-    refute group.present?
+    assert_not group.present?
   end
 end


### PR DESCRIPTION
- See commits for more detail.
- Done as part of the GOV.UK Developer Tooling working group: https://trello.com/c/pR7GEFfU/128-make-all-current-govuk-repos-use-rubocop-govuk-instead-of-govuk-lint