### PR TITLE
Use individual component Sass and JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,7 @@
-//= require govuk_publishing_components/dependencies
-//= require govuk_publishing_components/all_components
-//
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/accordion
+//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/components/govspeak
+
 //= require_tree ./govuk
 //= require_tree ./modules

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,7 +2,18 @@ $govuk-compatibility-govuktemplate: true;
 $govuk-compatibility-govukelements: true;
 $govuk-use-legacy-palette: false;
 
-@import "govuk_publishing_components/all_components";
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/component_support';
+@import 'govuk_publishing_components/components/accordion';
+@import 'govuk_publishing_components/components/breadcrumbs';
+@import 'govuk_publishing_components/components/feedback';
+@import 'govuk_publishing_components/components/govspeak';
+@import 'govuk_publishing_components/components/input';
+@import 'govuk_publishing_components/components/metadata';
+@import 'govuk_publishing_components/components/phase-banner';
+@import 'govuk_publishing_components/components/search';
+@import 'govuk_publishing_components/components/title';
+
 @import "mixins/margins";
 @import "mixins/print";
 

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -2,6 +2,13 @@
 
 $is-print: true;
 
-@import "govuk_publishing_components/all_components_print";
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/components/print/accordion';
+@import 'govuk_publishing_components/components/print/feedback';
+@import 'govuk_publishing_components/components/print/govspeak';
+@import 'govuk_publishing_components/components/print/metadata';
+@import 'govuk_publishing_components/components/print/search';
+@import 'govuk_publishing_components/components/print/title';
+
 @import "mixins/margins";
 @import "mixins/print";


### PR DESCRIPTION
Update service-manual-frontend to import the sass and Javascript for only the components it is using, instead of all components, as [documented here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-sass-for-individual-components) and [here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-javascript-for-individual-components).

## Filesize comparison

Before:

<img width="436" alt="Screenshot 2020-05-26 at 15 48 19" src="https://user-images.githubusercontent.com/861310/82916756-5e8efb80-9f6a-11ea-8f1c-d8faf989eb3f.png">

CSS: **916 KB** 

<img width="435" alt="Screenshot 2020-05-26 at 16 04 45" src="https://user-images.githubusercontent.com/861310/82916967-aada3b80-9f6a-11ea-8061-527d81c6b95e.png">

JS: **796 KB** 

After:

<img width="434" alt="Screenshot 2020-05-26 at 15 59 21" src="https://user-images.githubusercontent.com/861310/82916838-78304300-9f6a-11ea-8e15-eaf35faf68fd.png">

CSS: **441 KB**

<img width="433" alt="Screenshot 2020-05-26 at 16 04 28" src="https://user-images.githubusercontent.com/861310/82916993-b463a380-9f6a-11ea-8c52-a38416abc81d.png">


JS: **184 KB** 

Trello card: https://trello.com/c/GWttlBxs/228-upgrade-applications-to-use-individual-component-sass

