### PR TITLE
Switch asset host env var for change of asset host

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -86,6 +86,10 @@ module ServiceManualFrontend
     config.action_dispatch.rack_cache = nil
 
     # Path within public/ where assets are compiled to
-    config.assets.prefix = "/service-manual-frontend"
+    config.assets.prefix = "/assets/service-manual-frontend"
+
+    # allow overriding the asset host with an enironment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV["ASSET_HOST"]
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,10 +48,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  if ENV["GOVUK_ASSET_ROOT"].present?
-    config.asset_host = ENV["GOVUK_ASSET_ROOT"]
-  end
-
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,12 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Set GOVUK_ASSET_ROOT for heroku - for review apps we have the hostname set
-  # at the time of the app being built so can't be set up in the app.json
-  if !ENV.include?("GOVUK_ASSET_ROOT") && ENV["HEROKU_APP_NAME"]
-    ENV["GOVUK_ASSET_ROOT"] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
-  end
-
   # Code is not reloaded between requests.
   config.cache_classes = true
 
@@ -35,13 +29,6 @@ Rails.application.configure do
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
-
-  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
-  config.action_controller.asset_host = Plek.current.asset_root
-  config.slimmer.asset_host = Plek.current.find("static")
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This allows asset host to be set by ASSET_HOST env var. This is in
preparation for the assets of this app changing hostname from
assets.publishing.service.gov.uk to www.gov.uk.

As part of this change the path to assets is changed to
/assets/service-manual-frontend

The expectation is that this env var will only be set in dev
environments when proxying isn't set up for router.

This also removes some redundant slimmer config that sets the default.