### PR TITLE
Repoint email signups to generic API

### DIFF
--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -17,8 +17,7 @@ class ServiceStandardPresenter < ContentItemPresenter
   end
 
   def email_alert_signup_link
-    signups = content_item["links"].fetch("email_alert_signup", [])
-    signups.first["base_path"] if signups.any?
+    "/email-signup?topic=#{content_item['base_path']}"
   end
 
 private

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -25,8 +25,7 @@ class TopicPresenter < ContentItemPresenter
   end
 
   def email_alert_signup_link
-    signups = content_item["links"].fetch("email_alert_signup", [])
-    signups.first["base_path"] if signups.any?
+    "/email-signup?topic=#{content_item['base_path']}"
   end
 
   def phase

--- a/app/views/content_items/service_standard.html.erb
+++ b/app/views/content_items/service_standard.html.erb
@@ -46,7 +46,7 @@
 
     <div class="govuk-grid-column-one-third">
       <aside class="related govuk-!-padding-top-4">
-        <%= render partial: 'shared/email_signup' if @content_item.email_alert_signup_link.present? %>
+        <%= render partial: 'shared/email_signup' %>
         <% if @content_item.poster_url.present? %>
           <div class="related-item">
             <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="download-poster">

--- a/app/views/content_items/topic.html.erb
+++ b/app/views/content_items/topic.html.erb
@@ -71,7 +71,7 @@
           </nav>
         </div>
       <% end %>
-      <%= render partial: 'shared/email_signup' if @content_item.email_alert_signup_link.present? %>
+      <%= render partial: 'shared/email_signup' %>
       </aside>
     </div>
 

--- a/test/contracts/govuk_content_schemas_test.rb
+++ b/test/contracts/govuk_content_schemas_test.rb
@@ -5,7 +5,7 @@ class GovukContentSchemasTest < ActionDispatch::IntegrationTest
 
   all_examples_for_supported_formats.each do |content_item|
     test "can successfully render #{content_item['base_path']} schema example" do
-      content_store_has_item(content_item["base_path"], content_item)
+      stub_content_store_has_item(content_item["base_path"], content_item)
 
       get content_item["base_path"]
 

--- a/test/controllers/content_items_controller_test.rb
+++ b/test/controllers/content_items_controller_test.rb
@@ -22,7 +22,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   test "sets the expiry as sent by content-store" do
     content_item = content_store_has_schema_example("service_manual_guide", "service_manual_guide")
-    content_store_has_item(content_item["base_path"], content_item, max_age: 20)
+    stub_content_store_has_item(content_item["base_path"], content_item, max_age: 20)
 
     get :show, params: { path: path_for(content_item) }
     assert_response :success
@@ -31,7 +31,7 @@ class ContentItemsControllerTest < ActionController::TestCase
 
   test "honours cache-control private items" do
     content_item = content_store_has_schema_example("service_manual_guide", "service_manual_guide")
-    content_store_has_item(content_item["base_path"], content_item, private: true)
+    stub_content_store_has_item(content_item["base_path"], content_item, private: true)
 
     get :show, params: { path: path_for(content_item) }
     assert_response :success
@@ -43,7 +43,7 @@ class ContentItemsControllerTest < ActionController::TestCase
     utf8_path    = "government/case-studies/caf\u00e9-culture"
     content_item["base_path"] = "/#{utf8_path}"
 
-    content_store_has_item(content_item["base_path"], content_item)
+    stub_content_store_has_item(content_item["base_path"], content_item)
 
     get :show, params: { path: utf8_path }
     assert_response :success

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -15,7 +15,7 @@ class GuideTest < ActionDispatch::IntegrationTest
         ),
       )
       base_path = example.fetch("base_path")
-      content_store_has_item(base_path, example)
+      stub_content_store_has_item(base_path, example)
       visit base_path
 
       within(".app-metadata--heading") do

--- a/test/integration/service_standard_test.rb
+++ b/test/integration/service_standard_test.rb
@@ -63,7 +63,7 @@ class ServiceStandardTest < ActionDispatch::IntegrationTest
 
     assert page.has_link?(
       "email",
-      href: "/service-manual/service-standard/email-signup",
+      href: "/email-signup?topic=/service-manual/service-standard",
     )
   end
 

--- a/test/integration/topic_test.rb
+++ b/test/integration/topic_test.rb
@@ -11,7 +11,7 @@ class TopicTest < ActionDispatch::IntegrationTest
   end
 
   test "it uses topic description as meta description" do
-    content_store_has_item("/service-manual/test-topic", @topic_example.to_json)
+    stub_content_store_has_item("/service-manual/test-topic", @topic_example.to_json)
 
     visit "/service-manual/test-topic"
 
@@ -22,7 +22,7 @@ class TopicTest < ActionDispatch::IntegrationTest
 
   test "it doesn't write a meta description if there is none" do
     @topic_example.delete("description")
-    content_store_has_item("/service-manual/test-topic", @topic_example.to_json)
+    stub_content_store_has_item("/service-manual/test-topic", @topic_example.to_json)
 
     visit "/service-manual/test-topic"
 

--- a/test/integration/topic_test.rb
+++ b/test/integration/topic_test.rb
@@ -49,7 +49,7 @@ class TopicTest < ActionDispatch::IntegrationTest
 
     assert page.has_link?(
       "email",
-      href: "/service-manual/test-expanded-topic/email-signup",
+      href: "/email-signup?topic=/service-manual/test-expanded-topic",
     )
   end
 end

--- a/test/presenters/service_standard_presenter_test.rb
+++ b/test/presenters/service_standard_presenter_test.rb
@@ -62,12 +62,8 @@ class ServiceStandardPresenterTest < ActiveSupport::TestCase
   end
 
   test "#email_alert_signup returns a link to the email alert signup" do
-    assert_equal "/service-manual/service-standard/email-signup",
+    assert_equal "/email-signup?topic=/service-manual/service-standard",
                  presented_standard.email_alert_signup_link
-  end
-
-  test "#email_alert_signup does not error if no signup exists" do
-    assert_nil presented_standard(links: { email_alert_signup: [] }).email_alert_signup_link
   end
 
   test "#poster_url returns a link to the service standard poster" do

--- a/test/presenters/topic_presenter_test.rb
+++ b/test/presenters/topic_presenter_test.rb
@@ -61,14 +61,8 @@ class TopicPresenterTest < ActiveSupport::TestCase
   end
 
   test "#email_alert_signup returns a link to the email alert signup" do
-    assert_equal "/service-manual/test-expanded-topic/email-signup",
+    assert_equal "/email-signup?topic=/service-manual/test-expanded-topic",
                  presented_topic.email_alert_signup_link
-  end
-
-  test "#email_alert_signup does not error if no signup exists" do
-    topic = presented_topic(links: { email_alert_signup: [] })
-
-    assert_nil topic.email_alert_signup_link
   end
 
 private

--- a/test/support/govuk_content_schema_examples.rb
+++ b/test/support/govuk_content_schema_examples.rb
@@ -26,7 +26,7 @@ module GovukContentSchemaExamples
 
   def content_store_has_schema_example(schema_name, example_name, overrides = {})
     document = govuk_content_schema_example(schema_name, example_name, overrides)
-    content_store_has_item(document["base_path"], document)
+    stub_content_store_has_item(document["base_path"], document)
     document
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,7 +52,7 @@ class ActionDispatch::IntegrationTest
     example = govuk_content_schema_example(format, name, overrides)
     base_path = example.fetch("base_path")
 
-    content_store_has_item(base_path, example)
+    stub_content_store_has_item(base_path, example)
     visit base_path
   end
 end


### PR DESCRIPTION
https://trello.com/c/KNWv9Dgx/258-deprecate-and-remove-legacy-email-signup-pages

Depends on: https://github.com/alphagov/email-alert-frontend/pull/806

Previously we relied on each topic (and the service standard) having
an associated '/email-signup' content item. The matching criteria are
the topic itself, with a restriction on the document type [1]. The
additional document type restriction turns out to be redundant, since
service manual guides are the only document type linked to service
manual topics (and similarly for the service standard). This repoints
the email signup links to the generic page on Email Alert Frontend,
which supports signups to a given content item.

[1]: https://github.com/alphagov/service-manual-publisher/blob/master/app/presenters/topic_email_alert_signup_presenter.rb#L53

## Before

<img width="1280" alt="Screenshot 2020-05-29 at 11 56 02" src="https://user-images.githubusercontent.com/9029009/83252656-89b05f80-a1a3-11ea-9b3e-02db1fe61677.png">
<img width="1280" alt="Screenshot 2020-05-29 at 11 56 15" src="https://user-images.githubusercontent.com/9029009/83252657-8a48f600-a1a3-11ea-9e20-f5620fc2ba83.png">

## After

<img width="1280" alt="Screenshot 2020-05-29 at 11 55 48" src="https://user-images.githubusercontent.com/9029009/83252672-8f0daa00-a1a3-11ea-8b1c-dc54f3342310.png">
<img width="1280" alt="Screenshot 2020-05-29 at 11 56 32" src="https://user-images.githubusercontent.com/9029009/83252676-903ed700-a1a3-11ea-8cf0-71880804ac4c.png">
