### PR TITLE
Fix feedback layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,9 @@
       </div>
       <%= yield %>
     </main>
-    <%= render "govuk_publishing_components/components/feedback" %>
+    <div class="govuk-width-container">
+      <%= render "govuk_publishing_components/components/feedback" %>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## What / why
Fixes the layout of the feedback component being full screen width, it should be the width of the page. This is due to a change in the component where we removed the width constraint, preferring to let applications handle it.

## Visual Changes

Before:

<img width="1426" alt="Screenshot 2020-06-26 at 08 48 21" src="https://user-images.githubusercontent.com/861310/85833800-36bdce00-b78a-11ea-9862-5da0f0487685.png">

After:

<img width="1424" alt="Screenshot 2020-06-26 at 08 48 56" src="https://user-images.githubusercontent.com/861310/85833817-3d4c4580-b78a-11ea-8588-e3c76686b7ba.png">

Also fixes it on mobile:

<img width="396" alt="Screenshot 2020-06-26 at 08 51 54" src="https://user-images.githubusercontent.com/861310/85833860-50f7ac00-b78a-11ea-8492-74e83920765b.png">

## Pages to check

* /service-manual/
* /service-manual/helping-people-to-use-your-service
* /service-manual/design
* /service-manual/service-assessments
* /service-manual/service-standard
* /service-manual/service-standard/point-1-understand-user-needs
* /service-manual/communities
* /service-manual/communities/accessibility-community

