### PR TITLE
Add missing space to correct formatting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 * /service-manual/helping-people-to-use-your-service
 * /service-manual/design
 * /service-manual/service-assessments
-*/service-manual/service-standard
+* /service-manual/service-standard
 * /service-manual/service-standard/point-1-understand-user-needs
 * /service-manual/communities
 * /service-manual/communities/accessibility-community


### PR DESCRIPTION
## What
Very small change, adds a missing space into the github PR template so the list formats properly.

## Why
It wasn't showing one of the list items correctly when rendered.

