### PR TITLE
Restore asset compress after Rails 6 upgrade

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -83,6 +83,9 @@ module ServiceManualFrontend
     # Path within public/ where assets are compiled to
     config.assets.prefix = "/assets/service-manual-frontend"
 
+    # Compress JS using a preprocessor.
+    config.assets.js_compressor = :uglifier
+
     # Using a sass css compressor causes a scss file to be processed twice
     # (once to build, once to compress) which breaks the usage of "unquote"
     # to use CSS that has same function names as SCSS such as max.


### PR DESCRIPTION
## What

Changes to `production.rb` to restore asset compression to previous output.

## Why

* The upgrade to Rails 6 disabled JS compression because it now defaults to using webpack.

## Visual differences

None.