### PR TITLE
Install govuk_test and configure Jasmine to use it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "slimmer"
 gem "uglifier"
 
 group :development, :test do
+  gem "govuk_test"
   gem "jasmine"
   gem "jasmine_selenium_runner", require: false
   gem "rubocop-govuk"

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "uglifier"
 group :development, :test do
   gem "govuk_test"
   gem "jasmine"
-  gem "jasmine_selenium_runner", require: false
+  gem "jasmine_selenium_runner"
   gem "rubocop-govuk"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
+    brakeman (4.10.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.33.0)
@@ -119,6 +120,12 @@ GEM
       rails (>= 5.0.0.1)
       rouge
       sprockets (< 4)
+    govuk_test (2.0.0)
+      brakeman (~> 4.6)
+      capybara
+      puma
+      selenium-webdriver (>= 3.142)
+      webdrivers (>= 4)
     hashdiff (1.0.1)
     http-accept (1.7.0)
     http-cookie (1.0.3)
@@ -186,6 +193,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
+    puma (5.0.2)
+      nio4r (~> 2.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -354,6 +363,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers
   govuk_app_config
   govuk_publishing_components
+  govuk_test
   jasmine
   jasmine_selenium_runner
   listen

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,14 +1,7 @@
-require "jasmine/runners/selenium"
-require "webdrivers/chromedriver"
+require "jasmine_selenium_runner/configure_jasmine"
 
-Jasmine.configure do |config|
-  config.prevent_phantom_js_auto_install = true
-
-  config.runner = lambda { |formatter, jasmine_server_url|
-    options = Selenium::WebDriver::Chrome::Options.new
-    options.headless!
-
-    webdriver = Selenium::WebDriver.for(:chrome, options: options)
-    Jasmine::Runners::Selenium.new(formatter, jasmine_server_url, webdriver, 50)
-  }
+class HeadlessChromeJasmineConfigurer < JasmineSeleniumRunner::ConfigureJasmine
+  def selenium_options
+    { options: GovukTest.headless_chrome_selenium_options }
+  end
 end

--- a/spec/javascripts/support/jasmine_selenium_runner.yml
+++ b/spec/javascripts/support/jasmine_selenium_runner.yml
@@ -1,0 +1,2 @@
+browser: chrome
+configuration_class: HeadlessChromeJasmineConfigurer

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,12 +11,12 @@ require "slimmer/test"
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].sort.each { |file| require file }
 
+GovukTest.configure
+
 class ActiveSupport::TestCase
   include GovukContentSchemaExamples
   include DraftStackExamples
 end
-
-Capybara.default_driver = :rack_test
 
 class ActionDispatch::IntegrationTest
   # Make the Capybara DSL available in all integration tests
@@ -31,7 +31,4 @@ class ActionDispatch::IntegrationTest
   end
 end
 
-WebMock.disable_net_connect!(
-  allow_localhost: true,
-  allow: ["chromedriver.storage.googleapis.com"],
-)
+WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
This adds the govuk_test gem which provides Capybara configuration and other test utilities (notably Brakeman). It then configures Jasmine Selenium Runner to use this, which will allow these tests to succeed once https://github.com/alphagov/govuk-docker/pull/394 is merged.