### PR TITLE
Lint as part of the default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,13 @@
 require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
+
+begin
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
+rescue LoadError
+  # Rubocop isn't available in all environments
+end
+
+Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
+task default: %i[rubocop jasmine:ci test]

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -1,1 +1,0 @@
-Rake::Task[:default].enhance ["jasmine:ci"]


### PR DESCRIPTION
Trello: https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks

We had expected that all apps were linting with the default rake task
and removed the linting step from the Jenkins library [1]. However it
seems this app was missed.

The rails test task always seem to run last when part of the default
group despite any ordering. I've tried to make this at least appear
explicit by defining jasmine:ci before test, even though this is
different for how GOV.UK normally applies it.

[1]: https://github.com/alphagov/govuk-jenkinslib/pull/74
