### PR TITLE
Switch to use "link" query param for email signups

### DIFF
--- a/app/presenters/service_standard_presenter.rb
+++ b/app/presenters/service_standard_presenter.rb
@@ -17,7 +17,7 @@ class ServiceStandardPresenter < ContentItemPresenter
   end
 
   def email_alert_signup_link
-    "/email-signup?topic=#{content_item['base_path']}"
+    "/email-signup?link=#{content_item['base_path']}"
   end
 
 private

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -25,7 +25,7 @@ class TopicPresenter < ContentItemPresenter
   end
 
   def email_alert_signup_link
-    "/email-signup?topic=#{content_item['base_path']}"
+    "/email-signup?link=#{content_item['base_path']}"
   end
 
   def phase

--- a/test/integration/service_standard_test.rb
+++ b/test/integration/service_standard_test.rb
@@ -63,7 +63,7 @@ class ServiceStandardTest < ActionDispatch::IntegrationTest
 
     assert page.has_link?(
       "email",
-      href: "/email-signup?topic=/service-manual/service-standard",
+      href: "/email-signup?link=/service-manual/service-standard",
     )
   end
 

--- a/test/integration/topic_test.rb
+++ b/test/integration/topic_test.rb
@@ -49,7 +49,7 @@ class TopicTest < ActionDispatch::IntegrationTest
 
     assert page.has_link?(
       "email",
-      href: "/email-signup?topic=/service-manual/test-expanded-topic",
+      href: "/email-signup?link=/service-manual/test-expanded-topic",
     )
   end
 end

--- a/test/presenters/service_standard_presenter_test.rb
+++ b/test/presenters/service_standard_presenter_test.rb
@@ -62,7 +62,7 @@ class ServiceStandardPresenterTest < ActiveSupport::TestCase
   end
 
   test "#email_alert_signup returns a link to the email alert signup" do
-    assert_equal "/email-signup?topic=/service-manual/service-standard",
+    assert_equal "/email-signup?link=/service-manual/service-standard",
                  presented_standard.email_alert_signup_link
   end
 

--- a/test/presenters/topic_presenter_test.rb
+++ b/test/presenters/topic_presenter_test.rb
@@ -61,7 +61,7 @@ class TopicPresenterTest < ActiveSupport::TestCase
   end
 
   test "#email_alert_signup returns a link to the email alert signup" do
-    assert_equal "/email-signup?topic=/service-manual/test-expanded-topic",
+    assert_equal "/email-signup?link=/service-manual/test-expanded-topic",
                  presented_topic.email_alert_signup_link
   end
 


### PR DESCRIPTION
https://trello.com/c/oYRFCtBm/668-iterate-error-content-and-behaviour-for-new-signup-workflow

This is preferred for the signup API [1] [2].

[1]: https://github.com/alphagov/email-alert-frontend/pull/971
[2]: https://github.com/alphagov/email-alert-frontend/blob/5f132d43d0dfc378248b228525e1393a495931cb/app/controllers/content_item_signups_controller.rb#L43


## What
<!-- Description of the change being made -->

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

<!--
## Pages to check

* /service-manual/
* /service-manual/helping-people-to-use-your-service
* /service-manual/design
* /service-manual/service-assessments
* /service-manual/service-standard
* /service-manual/service-standard/point-1-understand-user-needs
* /service-manual/communities
* /service-manual/communities/accessibility-community

-->