### PR TITLE
Make use of gem components where possible

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -54,7 +54,14 @@
     <div class="govuk-grid-column-one-third app-sticky-element">
       <!--  Page contents -->
       <div class="page-contents js-page-contents">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-margin-top-3">Page contents:</h2>
+        <div class="govuk-!-margin-top-3">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Page contents:",
+            heading_level: 2,
+            font_size: "s",
+            margin_bottom: 1,
+          } %>
+        </div>
         <ul class="govuk-list app-page-contents__list">
           <% @content_item.header_links.each do |header_link| %>
             <li class="govuk-body-s">

--- a/app/views/content_items/homepage.html.erb
+++ b/app/views/content_items/homepage.html.erb
@@ -11,7 +11,12 @@
     <div class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-xl govuk-!-margin-bottom-6 app-hero__heading--inverse">Service Manual</h1>
+          <%= render "govuk_publishing_components/components/title", {
+            title: "Service Manual",
+            inverse: true,
+            margin_top: 0,
+            margin_bottom: 6,
+          } %>
           <p class="govuk-body-lead app-hero-lead app-hero__body--inverse govuk-!-padding-bottom-1">
             Helping teams to create and run great public services that meet the <%= link_to 'Service Standard', '/service-manual/service-standard', class: 'govuk-link app-link--inverse' %>.
           </p>
@@ -43,7 +48,12 @@
       <div class="govuk-grid-row">
         <% row_of_topics.each do |topic| %>
           <div class="govuk-grid-column-one-third">
-            <h2 class="govuk-heading-s govuk-!-margin-bottom-1"><%= link_to topic["title"], topic["base_path"], class: 'govuk-link' %></h2>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: sanitize(link_to topic["title"], topic["base_path"], class: 'govuk-link'),
+              heading_level: 2,
+              font_size: "s",
+              margin_bottom: 1,
+            } %>
             <p class="govuk-body-s"><%= topic["description"] %></p>
           </div>
         <% end %>
@@ -53,14 +63,20 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <div class="panel govuk-!-padding-top-3 govuk-!-margin-top-5">
-          <h2 class="govuk-heading-m">The Service Standard</h2>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "The Service Standard",
+            font_size: "m",
+          } %>
           <p class="govuk-body app-body">The <%= link_to 'Service Standard', '/service-manual/service-standard', class: 'govuk-link' %> provides the principles of building a good service. This manual explains what teams can do to build great services that will meet the standard.</p>
         </div>
       </div>
 
       <div class="govuk-grid-column-one-half">
         <div class="panel govuk-!-padding-top-3 govuk-!-margin-top-5">
-          <h2 class="govuk-heading-m">Communities of practice</h2>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Communities of practice",
+            font_size: "m",
+          } %>
           <p class="govuk-body app-body">You can view the <%= link_to 'communities of practice', '/service-manual/communities', class: 'govuk-link' %> to find more learning resources, see who has written the guidance in the manual and connect with digital people like you from across government.</p>
         </div>
       </div>

--- a/app/views/content_items/service_standard.html.erb
+++ b/app/views/content_items/service_standard.html.erb
@@ -30,18 +30,20 @@
   <!-- Points -->
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% @content_item.points.each do |point| %>
-        <div class="app-service-standard-point" id="criterion-<%= point.number -%>">
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-3 app-service-standard-point__title">
-            <span class="app-service-standard-point__number"><%= point.number %>.</span>
-            <%= point.title_without_number %>
-          </h2>
-          <div class="app-service-standard-point__details">
-            <%= "<p class='govuk-body'>#{point.description}</p>" if point.description.present? %>
-            <p class="govuk-body app-service-standard-point__link"><%= link_to "Read more about point #{ point.number }", point.base_path, class: 'govuk-link' %></p>
-          </div>
-        </div>
-      <% end %>
+      <ol class="govuk-list">
+        <% @content_item.points.each do |point| %>
+          <li class="app-service-standard-point" id="criterion-<%= point.number -%>">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-3 app-service-standard-point__title">
+              <span class="app-service-standard-point__number"><%= point.number %>.</span>
+              <%= point.title_without_number %>
+            </h2>
+            <div class="app-service-standard-point__details">
+              <%= "<p class='govuk-body'>#{point.description}</p>" if point.description.present? %>
+              <p class="govuk-body app-service-standard-point__link"><%= link_to "Read more about point #{ point.number }", point.base_path, class: 'govuk-link' %></p>
+            </div>
+          </li>
+        <% end %>
+      </ol>
     </div>
 
     <div class="govuk-grid-column-one-third">

--- a/app/views/content_items/service_toolkit.html.erb
+++ b/app/views/content_items/service_toolkit.html.erb
@@ -8,8 +8,12 @@
     <div class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="app-hero__title govuk-heading-xl govuk-!-margin-bottom-6 app-hero__heading--inverse">Design and build government services</h1>
-
+          <%= render "govuk_publishing_components/components/title", {
+            title: "Design and build government services",
+            inverse: true,
+            margin_top: 0,
+            margin_bottom: 6,
+          } %>
           <p class="app-hero__description govuk-body-l govuk-!-margin-bottom-3 app-hero__body--inverse">
             All you need to design, build and run services that meet government standards.
           </p>
@@ -24,7 +28,12 @@
     <div class="app-collection govuk-!-margin-top-7">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-          <h2 id="<%= collection["title"].parameterize %>" class="app-collection__title govuk-heading-l govuk-!-margin-bottom-1"><%= collection["title"] %></h2>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: collection["title"],
+            font_size: "l",
+            margin_bottom: 1,
+            id: collection["title"].parameterize,
+          } %>
           <p class="app-collection__description govuk-body-l"><%= collection["description"] %></p>
         </div>
       </div>
@@ -32,7 +41,12 @@
         <div class="govuk-grid-row">
           <% row_of_links.each do | link | %>
             <div class="govuk-grid-column-one-half">
-              <h3 class="app-collection__link govuk-heading-m govuk-!-margin-bottom-2"><%= link_to link["title"], link["url"], class: "govuk-link" %></h3>
+              <%= render "govuk_publishing_components/components/heading", {
+                text: sanitize(link_to link["title"], link["url"], class: "govuk-link"),
+                heading_level: 3,
+                font_size: "m",
+                margin_bottom: 2,
+              } %>
               <p class="app-collection__link-description govuk-body"><%= link["description"] %></p>
             </div>
           <% end %>

--- a/app/views/content_items/topic.html.erb
+++ b/app/views/content_items/topic.html.erb
@@ -30,23 +30,31 @@
           items: @content_item.accordion_content
         } %>
       <% else %>
-        <% @content_item.groups.each_with_index { |link_group| %>
+        <% @content_item.groups.each_with_index do |link_group| %>
           <% if link_group.name.present? %>
             <div class="subsection__header govuk-!-margin-bottom-3">
-              <h2 class="govuk-heading-m govuk-!-margin-bottom-1 govuk-!-margin-top-3 subsection__title" id="<%= link_group.name.parameterize %>"><%= link_group.name %></h2>
-            <% if link_group.description.present? %>
-              <p class="govuk-body govuk-!-margin-bottom-1 subsection__description"><%= link_group.description %></p>
-            <% end %>
+              <%= render "govuk_publishing_components/components/heading", {
+                text: link_group.name,
+                font_size: "m",
+                margin_bottom: 1,
+                id: link_group.name.parameterize,
+              } %>
+              <% if link_group.description.present? %>
+                <p class="govuk-body govuk-!-margin-bottom-1 subsection__description"><%= link_group.description %></p>
+              <% end %>
             </div>
           <% end %>
-          <ul class="govuk-list govuk-!-margin-bottom-9">
-            <% link_group.linked_items.each { |linked_item| %>
-              <li>
-                <%= link_to linked_item.label, linked_item.href, class: 'govuk-link' %>
-              </li>
-            <% } %>
-          </ul>
-        <% } %>
+          <%
+            link_items = []
+
+            link_group.linked_items.each do |linked_item|
+              link_items << sanitize(link_to linked_item.label, linked_item.href, class: 'govuk-link')
+            end
+          %>
+          <%= render "govuk_publishing_components/components/list", {
+            items: link_items
+          } %>
+        <% end %>
       <% end %>
     </div>
 
@@ -54,20 +62,24 @@
       <aside class="related govuk-!-margin-top-3">
       <% if @content_item.content_owners.any? %>
         <div class="related-item govuk-!-padding-top-4 govuk-!-margin-bottom-5">
-          <h2 class="related-item__title govuk-heading-s govuk-!-margin-bottom-2" id="related-communities">
-            <%= topic_related_communities_title(@content_item.content_owners) -%>
-          </h2>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: topic_related_communities_title(@content_item.content_owners),
+            font_size: "s",
+            margin_bottom: 2,
+            id: "related-communities",
+          } %>
           <p class="related-item__description govuk-body">
             Find out what the cross-government community does and how to get involved.
           </p>
           <nav role="navigation" aria-labelledby="related-communities" class="related-communities">
-            <ul class="related-item__list govuk-list">
-              <% @content_item.content_owners.each do |content_owner| %>
-                <li class="related-item__list-item govuk-body-s">
-                  <%= link_to content_owner.title, content_owner.href, class: 'govuk-link' %>
-                </li>
-              <% end %>
-            </ul>
+            <%
+              related_items = @content_item.content_owners.map do |content_owner|
+                sanitize(link_to content_owner.title, content_owner.href, class: 'govuk-link')
+              end
+            %>
+            <%= render "govuk_publishing_components/components/list", {
+              items: related_items
+            } %>
           </nav>
         </div>
       <% end %>

--- a/app/views/shared/_email_signup.html.erb
+++ b/app/views/shared/_email_signup.html.erb
@@ -1,7 +1,10 @@
 <div class="related-item govuk-!-padding-top-4">
-  <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="related-subscriptions">
-    Get notifications
-  </h2>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Get notifications",
+    font_size: "s",
+    margin_bottom: 2,
+    id: "related-subscriptions",
+  } %>
   <p class="govuk-body">When any guidance within this topic is updated
     <%= link_to "email", @content_item.email_alert_signup_link, class: 'govuk-link related-item__email-link' %>
   </p>

--- a/test/integration/service_standard_test.rb
+++ b/test/integration/service_standard_test.rb
@@ -45,15 +45,15 @@ class ServiceStandardTest < ActionDispatch::IntegrationTest
   test "each point has an anchor tag so that they can be linked to externally" do
     setup_and_visit_example("service_manual_service_standard", "service_manual_service_standard")
 
-    within('div[id="criterion-1"]') do
+    within("#criterion-1") do
       assert page.has_content?("1. Understand user needs"), "Anchor is incorrect"
     end
 
-    within('div[id="criterion-2"]') do
+    within("#criterion-2") do
       assert page.has_content?("2. Do ongoing user research"), "Anchor is incorrect"
     end
 
-    within('div[id="criterion-3"]') do
+    within("#criterion-3") do
       assert page.has_content?("3. Have a multidisciplinary team"), "Anchor is incorrect"
     end
   end


### PR DESCRIPTION
## What
Update several instances of custom markup or markup directly from the design system.

## Why
This is part of an ongoing effort in the govuk accessibility team to use components in as many places as possible, ensuring that we can more easily deploy bugfixes and accessibility updates across our apps and avoid blind spots in our code coverage.

No visual changes.

[Card](https://trello.com/c/yB2tjxwt/564-update-service-manual-frontend-to-use-components)