### PR TITLE
Delete current-location.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,5 +4,4 @@
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
 
-//= require_tree ./govuk
 //= require_tree ./modules

--- a/app/assets/javascripts/govuk/current_location.js
+++ b/app/assets/javascripts/govuk/current_location.js
@@ -1,8 +1,0 @@
-(function (root) {
-  'use strict'
-  root.GOVUK = root.GOVUK || {}
-
-  root.GOVUK.getCurrentLocation = function () {
-    return root.location
-  }
-}(window))


### PR DESCRIPTION
## What
Delete current-location.js

## Why
Already [available via GOV.UK Publishing Components](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/lib/current-location.js)

## Visual Changes
n/a