### PR TITLE
Add missing tests

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,8 +6,4 @@ module ApplicationHelper
   def wrapper_class
     "direction-#{page_text_direction}" if page_text_direction
   end
-
-  def contact_govuk_path
-    "/contact/govuk"
-  end
 end

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -25,19 +25,11 @@ class ContentItemPresenter
     true
   end
 
-  def use_new_style_feedback_form?
-    true
-  end
-
   def format
     content_item["document_type"].sub(/^service_manual_/, "")
   end
 
 private
-
-  def display_time(timestamp)
-    I18n.l(Date.parse(timestamp), format: "%-d %B %Y") if timestamp
-  end
 
   def sorted_locales(translations)
     translations.sort_by { |t| t["locale"] == I18n.default_locale.to_s ? "" : t["locale"] }

--- a/app/presenters/homepage_presenter.rb
+++ b/app/presenters/homepage_presenter.rb
@@ -1,8 +1,4 @@
 class HomepagePresenter < ContentItemPresenter
-  def breadcrumbs
-    []
-  end
-
   def include_search_in_header?
     false
   end

--- a/app/presenters/service_toolkit_presenter.rb
+++ b/app/presenters/service_toolkit_presenter.rb
@@ -3,10 +3,6 @@ class ServiceToolkitPresenter < ContentItemPresenter
     false
   end
 
-  def use_new_style_feedback_form?
-    false
-  end
-
   def collections
     details.fetch("collections", [])
   end

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -1,6 +1,9 @@
 class TopicPresenter < ContentItemPresenter
   ContentOwner = Struct.new(:title, :href)
 
+  attr_reader :visually_collapsed
+  alias_method :visually_collapsed?, :visually_collapsed
+
   def initialize(content_item)
     super
     @visually_collapsed = content_item["details"]["visually_collapsed"]
@@ -30,10 +33,6 @@ class TopicPresenter < ContentItemPresenter
 
   def phase
     "beta"
-  end
-
-  def visually_collapsed?
-    @visually_collapsed
   end
 
   def visually_expanded?

--- a/test/integration/topic_test.rb
+++ b/test/integration/topic_test.rb
@@ -44,6 +44,27 @@ class TopicTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "it doesn't display content in accordian if not eligible" do
+    setup_and_visit_example("service_manual_topic", "service_manual_topic")
+
+    assert_not page.has_css?(".gem-c-accordion")
+  end
+
+  test "it displays content using an accordian if eligible" do
+    content_item = govuk_content_schema_example("service_manual_topic", "service_manual_topic")
+    third_linked_item = { content_id: SecureRandom.uuid, title: "linky", base_path: "/basey" }
+    third_group = { name: "Group 3", description: "The third group", content_ids: [third_linked_item[:content_id]] }
+
+    content_item["links"]["linked_items"] << third_linked_item
+    content_item["details"]["groups"] << third_group
+    content_item["details"]["visually_collapsed"] = true
+
+    stub_content_store_has_item(content_item["base_path"], content_item)
+    visit content_item["base_path"]
+
+    assert page.has_css?(".gem-c-accordion")
+  end
+
   test "it includes a link to subscribe for email alerts" do
     setup_and_visit_example("service_manual_topic", "service_manual_topic")
 

--- a/test/presenters/topic_presenter_test.rb
+++ b/test/presenters/topic_presenter_test.rb
@@ -26,6 +26,19 @@ class TopicPresenterTest < ActiveSupport::TestCase
     assert_equal ["/service-manual/user-centred-design/accessibility", "/service-manual/user-centred-design/resources/patterns/addresses"], group_items.map(&:href)
   end
 
+  test "returns accordion content data" do
+    accordion_content = presented_topic.accordion_content
+    first_accordion_section = {
+      heading: { text: "Group 1" },
+      summary: { text: "The first group" },
+      content: { html: "<ul class=\"govuk-list\">\n<li><a class=\"govuk-link\" href=\"/service-manual/user-centred-design/accessibility\">Accessibility</a></li>\n<li><a class=\"govuk-link\" href=\"/service-manual/user-centred-design/resources/patterns/addresses\">Addresses</a></li>\n</ul>" },
+      expanded: true,
+    }
+
+    assert_equal 2, accordion_content.count
+    assert_equal first_accordion_section, accordion_content.first
+  end
+
   test "does not fail if there are no linked_groups" do
     topic = presented_topic(details: { groups: nil })
 


### PR DESCRIPTION
Clean up and adds some missing tests for Service Manual Frontend in preparation for enabling continuous deployment.

Main features of the app are tested, the two Javascript modules are both tested and the ruby test coverage is now near 100%:

```
Coverage report generated for Minitest, Unit Tests to /govuk/service-manual-frontend/coverage. 248 / 249 LOC (99.6%) covered. 
```

Trello:
https://trello.com/c/zu7IYR6C/2385-enable-continuous-deployment-for-service-manual-frontend