### PR TITLE
Remove top timestamp

### DIFF
--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -79,7 +79,7 @@
         <div class="app-change-history__latest-change">
           <% if @content_item.content_owners.any? %>
             <%= render "govuk_publishing_components/components/metadata", {
-              last_updated: time_ago_in_words(@content_item.visible_updated_at),
+              last_updated: "#{time_ago_in_words(@content_item.visible_updated_at)} ago",
               from: @content_item.content_owners.map { |content_owner|
                 link_to(content_owner.title, content_owner.href)
               }

--- a/app/views/content_items/guide.html.erb
+++ b/app/views/content_items/guide.html.erb
@@ -42,7 +42,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds app-metadata--heading">
       <%= render "govuk_publishing_components/components/metadata", {
-        last_updated: "#{time_ago_in_words(@content_item.visible_updated_at)} ago",
         from: @content_item.content_owners.map { |content_owner|
           link_to(content_owner.title, content_owner.href)
         }

--- a/test/integration/guide_test.rb
+++ b/test/integration/guide_test.rb
@@ -18,7 +18,7 @@ class GuideTest < ActionDispatch::IntegrationTest
       stub_content_store_has_item(base_path, example)
       visit base_path
 
-      within(".app-metadata--heading") do
+      within(".app-change-history") do
         assert page.has_content?("5 minutes ago")
       end
     end
@@ -28,7 +28,7 @@ class GuideTest < ActionDispatch::IntegrationTest
     travel_to Time.zone.local(2015, 10, 10, 0, 0, 0) do
       setup_and_visit_example("service_manual_guide", "service_manual_guide")
 
-      within(".app-metadata--heading") do
+      within(".app-change-history") do
         assert page.has_content?("about 16 hours ago")
       end
     end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Removal of timestamp at the top of each guidance page: Taking out the ‘Last updated’ information below the guidance title –while the timestamp information remains at the bottom of each guidance page.

## Why
User research has shown that users of the Service Manual are irritated and trusting guidance less if it has an old timestamp. It distracts from useful and potentially recently reviewed but unchanged guidance. The timestamp information remains available to users at the bottom of each page. Further details can be found in this [user research findings document](https://docs.google.com/presentation/d/1xYaMannwtE-KlLb37RZcAaxbO4EIxWQjbvvSg-k-lKU/edit?usp=sharing).

## Visual Changes
Removal of ‘last updated’ information on top of the page – no other visual changes.

<!--
## Pages to check

* /service-manual/
* /service-manual/helping-people-to-use-your-service
* /service-manual/design
* /service-manual/service-assessments
* /service-manual/service-standard
* /service-manual/service-standard/point-1-understand-user-needs
* /service-manual/communities
* /service-manual/communities/accessibility-community

-->
