### PR TITLE
Add RFC 141 healthcheck endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
 
   with_options format: false do |r|
     r.get "healthcheck", to: proc { [200, {}, [""]] }
+    r.get "healthcheck/live", to: proc { [200, {}, %w[OK]] }
+    r.get "healthcheck/ready", to: GovukHealthcheck.rack_response
     r.get "*path" => "content_items#show", constraints: { path: %r{.*} }
   end
 end


### PR DESCRIPTION
Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
