### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,6 @@ Rails.application.routes.draw do
           }
 
   with_options format: false do |r|
-    r.get "healthcheck", to: proc { [200, {}, [""]] }
     r.get "healthcheck/live", to: proc { [200, {}, %w[OK]] }
     r.get "healthcheck/ready", to: GovukHealthcheck.rack_response
     r.get "*path" => "content_items#show", constraints: { path: %r{.*} }


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
