### PR TITLE
Switch to new Design System link styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-compatibility-govukelements: true;
 $govuk-use-legacy-palette: false;
+$govuk-new-link-styles: true;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';

--- a/app/assets/stylesheets/modules/_typography.scss
+++ b/app/assets/stylesheets/modules/_typography.scss
@@ -3,14 +3,3 @@
 .app-body-s {
   line-height: 1.45;
 }
-
-.app-link--inverse {
-  &:link,
-  &:visited {
-    color: govuk-colour("white");
-  }
-
-  &:focus {
-    @include govuk-focused-text;
-  }
-}

--- a/app/views/content_items/homepage.html.erb
+++ b/app/views/content_items/homepage.html.erb
@@ -18,7 +18,7 @@
             margin_bottom: 6,
           } %>
           <p class="govuk-body-lead app-hero-lead app-hero__body--inverse govuk-!-padding-bottom-1">
-            Helping teams to create and run great public services that meet the <%= link_to 'Service Standard', '/service-manual/service-standard', class: 'govuk-link app-link--inverse' %>.
+            Helping teams to create and run great public services that meet the <%= link_to 'Service Standard', '/service-manual/service-standard', class: 'govuk-link govuk-link--inverse' %>.
           </p>
           <form action="/search" method="get" role="search">
             <input type="hidden" name="filter_manual" value="/service-manual">
@@ -33,7 +33,7 @@
         </div>
         <div class="govuk-grid-column-one-third">
           <p class="govuk-body-s app-hero__body--inverse">
-            <%= link_to 'Contact the Service Manual team', '/contact/govuk', class: 'govuk-link app-link--inverse' %>
+            <%= link_to 'Contact the Service Manual team', '/contact/govuk', class: 'govuk-link govuk-link--inverse' %>
             with any comments or questions.
           </p>
         </div>


### PR DESCRIPTION
# What
Set `$govuk-new-link-styles: true` in `application.scss` to enable the new link styles from the Design System.

# Why
The new DS link styles are being rolled out across GOVUK.
We've already applied the new styles to the individual components in the component gem. The next step is to enable them on the frontend applications themselves.
This switches `service-manual-frontend` over to the new styles by setting the `govuk-new-link-styles` flag to `true` in the
`application.scss` file. 

The types of pages rendered by this application are primarily content heavy pages. There are no app-level components to speak of, which makes transitioning to the new link styles a fairly straightforward process. I've tested this on the [Example pages rendered by service-manual-frontend](https://docs.publishing.service.gov.uk/apps/service-manual-frontend.html#example-pages-rendered-by-service-manual-frontend) from the dev docs.


------

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


<!--
## Pages to check

* /service-manual/
* /service-manual/helping-people-to-use-your-service
* /service-manual/design
* /service-manual/service-assessments
* /service-manual/service-standard
* /service-manual/service-standard/point-1-understand-user-needs
* /service-manual/communities
* /service-manual/communities/accessibility-community

-->
