### PR TITLE
Remove specified search id

### DIFF
--- a/app/views/content_items/homepage.html.erb
+++ b/app/views/content_items/homepage.html.erb
@@ -23,7 +23,6 @@
           <form action="/search" method="get" role="search">
             <input type="hidden" name="filter_manual" value="/service-manual">
             <%= render "govuk_publishing_components/components/search", {
-              id: "search",
               label_text: "Search the service manual",
               name: "q",
               on_govuk_blue: true,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove the specified search id so that the id is generated instead.

## Why
Previously, clicking on the label in the search box did not move focus to the search input, which made the search box feel broken.

This was happening because there are multiple things on the page with an id of 'search'. The search component generates an id with a unique number appended to avoid this happening. There doesn't seem to be a reason why this input needs a specific id, so this commit removes it so it gets generated instead.

Page to check: https://govuk-servic-make-searc-xyvved.herokuapp.com/service-manual
