### PR TITLE
Fix markup for page titles

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,9 @@
 </head>
 <body<% if content_for?(:body_classes) %> class="<%= content_for(:body_classes) %>"<% end %>>
   <div class="slimmer-inside-header">
-      <span class="header-title"><%= content_for(:header_title) || "Service Manual" %></span>
+    <span class="govuk-header__product-name gem-c-header__product-name">
+      <%= content_for(:header_title) || "Service Manual" %>
+    </span>
   </div>
 
   <div id="wrapper" class="app-!-full-width-override <%= wrapper_class %>">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Change markup for header sent to Slimmer that gets injected into template. This is part of fixing the header.

[Trello card](https://trello.com/c/7xbAX1Uk/711-bug-fix-service-manual-header)

### Related PRs

* https://github.com/alphagov/govuk_publishing_components/pull/2521
* https://github.com/alphagov/static/pull/2672

## Why

Since the change to new layout header, the markup became out of date and wasn't applying correct styles.


## Visual Changes

## Before

![www gov uk_service-manual](https://user-images.githubusercontent.com/424772/146188350-d67aa003-b3a7-4407-85a4-79eab19413c4.png)

![www gov uk_service-toolkit](https://user-images.githubusercontent.com/424772/146188364-90a2586a-c4a1-471e-b13f-1fcad826b5ad.png)

## After

![service-manual-frontend dev gov uk_service-manual](https://user-images.githubusercontent.com/424772/146188537-e7336e9d-8cae-47c7-b8e2-52434a52f691.png)

![service-manual-frontend dev gov uk_service-toolkit](https://user-images.githubusercontent.com/424772/146188551-79fee06e-1572-4edb-846d-087856a73b4f.png)



<!--
## Pages to check

* /service-manual/
* /service-manual/helping-people-to-use-your-service
* /service-manual/design
* /service-manual/service-assessments
* /service-manual/service-standard
* /service-manual/service-standard/point-1-understand-user-needs
* /service-manual/communities
* /service-manual/communities/accessibility-community

-->
