### PR TITLE
Remove jQuery from highlight active section

### DIFF
--- a/app/assets/javascripts/modules/highlight-active-section-heading.js
+++ b/app/assets/javascripts/modules/highlight-active-section-heading.js
@@ -1,148 +1,156 @@
-;(function (Modules, root) {
-  'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-  var $ = root.$
-  var $window = $(root)
+(function (Modules) {
+  function HighlightActiveSectionHeading ($module) {
+    this.$module = $module
+    this._hasResized = true
+    this._hasScrolled = true
+    this._interval = 50
+    this.anchorIDs = []
+  }
 
-  Modules.HighlightActiveSectionHeading = function () {
-    var self = this
-    var _hasResized = true
-    var _hasScrolled = true
-    var _interval = 50
-    var anchorIDs = []
+  HighlightActiveSectionHeading.prototype.init = function () {
+    window.addEventListener('resize', function () { this._hasResized = true }.bind(this))
+    window.addEventListener('scroll', function () { this._hasScrolled = true }.bind(this))
 
-    self.getWindowDimensions = function () {
-      return {
-        height: $window.height(),
-        width: $window.width()
-      }
-    }
+    setInterval(this.checkResize.bind(this), this._interval)
+    setInterval(this.checkScroll.bind(this), this._interval)
 
-    self.getWindowPositions = function () {
-      return {
-        scrollTop: $window.scrollTop()
-      }
-    }
+    this.anchors = this.$module.querySelectorAll('.js-page-contents a')
+    this.getAnchors()
 
-    self.getElementOffset = function ($el) {
-      return $el.offset()
-    }
+    this.checkResize()
+    this.checkScroll()
+  }
 
-    self.start = function ($el) {
-      $window.resize(self.hasResized)
-      $window.scroll(self.hasScrolled)
-
-      setInterval(self.checkResize, _interval)
-      setInterval(self.checkScroll, _interval)
-
-      self.$anchors = $el.find('.js-page-contents a')
-      self.getAnchors()
-
-      self.checkResize()
-      self.checkScroll()
-    }
-
-    self.hasResized = function () {
-      _hasResized = true
-      return _hasResized
-    }
-
-    self.hasScrolled = function () {
-      _hasScrolled = true
-      return _hasScrolled
-    }
-
-    self.checkResize = function () {
-      if (_hasResized) {
-        _hasResized = false
-        _hasScrolled = true
-      }
-    }
-
-    self.checkScroll = function () {
-      if (_hasScrolled) {
-        _hasScrolled = false
-        var windowDimensions = self.getWindowDimensions()
-        if (windowDimensions.width <= 768) {
-          self.removeActiveItem()
-        } else {
-          self.updateActiveNavItem()
-        }
-      }
-    }
-
-    self.getAnchors = function () {
-      $.each(self.$anchors, function (i) {
-        var anchorID = $(this).attr('href')
-        // e.g. anchorIDs['#meeting-the-digital-service-standard', '#understand-your-users', '#research-continually']
-        anchorIDs.push(anchorID)
-      })
-    }
-
-    self.getHeadingPosition = function ($theID) {
-      return $theID.offset()
-    }
-
-    self.getNextHeadingPosition = function ($theNextID) {
-      return $theNextID.offset()
-    }
-
-    self.getFooterPosition = function ($theID) {
-      return $theID.offset()
-    }
-
-    self.getDistanceBetweenHeadings = function (headingPosition, nextHeadingPosition) {
-      var distanceBetweenHeadings = (nextHeadingPosition - headingPosition)
-      return distanceBetweenHeadings
-    }
-
-    self.updateActiveNavItem = function () {
-      var windowVerticalPosition = self.getWindowPositions().scrollTop
-      var footerPosition = self.getFooterPosition($('.govuk-footer'))
-
-      $.each(self.$anchors, function (i) {
-        var theID = anchorIDs[i]
-        var theNextID = anchorIDs[i + 1]
-
-        var $theID = $(theID)
-        var $theNextID = $(theNextID)
-
-        var headingPosition = self.getHeadingPosition($theID)
-
-        if (!headingPosition) {
-          return
-        }
-
-        headingPosition = headingPosition.top
-        headingPosition = headingPosition - 53 // fix the offset from top of page
-
-        if (theNextID) {
-          var nextHeadingPosition = self.getNextHeadingPosition($theNextID).top
-        }
-
-        var distanceBetweenHeadings = self.getDistanceBetweenHeadings(headingPosition, nextHeadingPosition)
-        var isPastHeading
-
-        if (distanceBetweenHeadings) {
-          isPastHeading = (windowVerticalPosition >= headingPosition && windowVerticalPosition < (headingPosition + distanceBetweenHeadings))
-        } else {
-          // when distanceBetweenHeadings is false (as there isn't a next heading)
-          isPastHeading = (windowVerticalPosition >= headingPosition && windowVerticalPosition < footerPosition.top)
-        }
-
-        if (isPastHeading) {
-          self.setActiveItem(theID)
-        }
-      })
-    }
-
-    self.setActiveItem = function (theID) {
-      self.$anchors.removeClass('active')
-      self.$anchors.filter("[href='" + theID + "']").addClass('active')
-    }
-
-    self.removeActiveItem = function () {
-      self.$anchors.removeClass('active')
+  HighlightActiveSectionHeading.prototype.checkResize = function () {
+    if (this._hasResized) {
+      this._hasResized = false
+      this._hasScrolled = true
     }
   }
-})(window.GOVUK.Modules, window)
+
+  HighlightActiveSectionHeading.prototype.checkScroll = function () {
+    if (this._hasScrolled) {
+      this._hasScrolled = false
+      var windowDimensions = this.getWindowDimensions()
+      if (windowDimensions.width <= 768) {
+        this.removeActiveItem()
+      } else {
+        this.updateActiveNavItem()
+      }
+    }
+  }
+
+  HighlightActiveSectionHeading.prototype.getWindowDimensions = function () {
+    return {
+      height: window.innerHeight,
+      width: window.innerWidth
+    }
+  }
+
+  HighlightActiveSectionHeading.prototype.getAnchors = function () {
+    for (var i = 0; i < this.anchors.length; i++) {
+      var anchorID = this.anchors[i].getAttribute('href')
+      // e.g. anchorIDs['#meeting-the-digital-service-standard', '#understand-your-users', '#research-continually']
+      this.anchorIDs.push(anchorID)
+    }
+  }
+
+  HighlightActiveSectionHeading.prototype.updateActiveNavItem = function () {
+    var windowVerticalPosition = this.getWindowPositions()
+    var footerPosition = this.getFooterPosition()
+
+    for (var i = 0; i < this.anchors.length; i++) {
+      var theID = this.anchorIDs[i]
+      var theNextID = this.anchorIDs[i + 1]
+
+      var $theID = document.getElementById(theID.substring(1)) // remove the # at the start
+      var $theNextID = theNextID ? document.getElementById(theNextID.substring(1)) : null // remove the # at the start
+
+      var headingPosition = this.getHeadingPosition($theID)
+      if (!headingPosition) {
+        return
+      }
+
+      headingPosition = headingPosition - 53 // fix the offset from top of page
+
+      if (theNextID) {
+        var nextHeadingPosition = this.getNextHeadingPosition($theNextID)
+      }
+
+      var distanceBetweenHeadings = this.getDistanceBetweenHeadings(headingPosition, nextHeadingPosition)
+      var isPastHeading
+
+      if (distanceBetweenHeadings) {
+        isPastHeading = (windowVerticalPosition >= headingPosition && windowVerticalPosition < (headingPosition + distanceBetweenHeadings))
+      } else {
+        // when distanceBetweenHeadings is false (as there isn't a next heading)
+        isPastHeading = (windowVerticalPosition >= headingPosition && windowVerticalPosition < footerPosition)
+      }
+
+      if (isPastHeading) {
+        this.setActiveItem(theID)
+      }
+    }
+  }
+
+  HighlightActiveSectionHeading.prototype.getFooterPosition = function () {
+    var footer = document.querySelector('.govuk-footer')
+    if (footer) {
+      return this.getElementPosition(footer)
+    }
+  }
+
+  // these two functions call getElementPosition because the test needs to individually
+  // override them - otherwise we could combine these four functions into one
+  HighlightActiveSectionHeading.prototype.getHeadingPosition = function (element) {
+    return this.getElementPosition(element)
+  }
+
+  HighlightActiveSectionHeading.prototype.getNextHeadingPosition = function (element) {
+    return this.getHeadingPosition(element)
+  }
+
+  HighlightActiveSectionHeading.prototype.getElementPosition = function (element) {
+    if (element) {
+      var rect = element.getBoundingClientRect()
+      var offset = {
+        top: rect.top + window.scrollY,
+        left: rect.left + window.scrollX
+      }
+      return offset.top
+    }
+  }
+
+  HighlightActiveSectionHeading.prototype.getDistanceBetweenHeadings = function (headingPosition, nextHeadingPosition) {
+    var distanceBetweenHeadings = (nextHeadingPosition - headingPosition)
+    return distanceBetweenHeadings
+  }
+
+  HighlightActiveSectionHeading.prototype.setActiveItem = function (theID) {
+    for (var i = 0; i < this.anchors.length; i++) {
+      var href = this.anchors[i].getAttribute('href')
+      if (href === theID) {
+        this.anchors[i].classList.add('active')
+      } else {
+        this.anchors[i].classList.remove('active')
+      }
+    }
+  }
+
+  HighlightActiveSectionHeading.prototype.removeActiveItem = function () {
+    for (var i = 0; i < this.anchors.length; i++) {
+      this.anchors[i].classList.remove('active')
+    }
+  }
+
+  HighlightActiveSectionHeading.prototype.getWindowPositions = function () {
+    var doc = document.documentElement
+    var top = (window.pageYOffset || doc.scrollTop) - (doc.clientTop || 0)
+    return top
+  }
+
+  Modules.HighlightActiveSectionHeading = HighlightActiveSectionHeading
+})(window.GOVUK.Modules)

--- a/spec/javascripts/highlight-active-section-heading-spec.js
+++ b/spec/javascripts/highlight-active-section-heading-spec.js
@@ -7,32 +7,36 @@ describe('A highlight active section heading module', function () {
   var $element
 
   beforeEach(function () {
-    module = new GOVUK.Modules.HighlightActiveSectionHeading()
-
-    $element = $('<div class="govuk-grid-row" data-module="highlight-active-section-heading">\
-      <div class="govuk-grid-column-one-third">\
-        <div class="page-contents js-page-contents js-stick-at-top-when-scrolling">\
-          <h2 class="page-contents__title">Page contents:</h2>\
-          <ul class="page-contents__list">\
-            <li><a href="#section-1">Section 1</a></li>\
-            <li><a href="#section-2">Section 2</a></li>\
-            <li><a href="#section-3">Section 3</a></li>\
-          </ul>\
-        </div>\
-      </div>\
-      <div class="govuk-grid-column-two-thirds">\
-        <div class="govspeak-wrapper">\
-          <div class="govuk-govspeak">\
-            <h2 id="section-1">Section 1</h2>\
-            <p>Section 1 text</p>\
-            <h2 id="section-2">Section 2</h2>\
-            <p>Section 2 text</p>\
-            <h2 id="section-3">Section 3</h2>\
-            <p>Section 3 text</p>\
+    $element = $(
+      '<div>\
+        <div class="govuk-grid-row" data-module="highlight-active-section-heading">\
+          <div class="govuk-grid-column-one-third">\
+            <div class="page-contents js-page-contents js-stick-at-top-when-scrolling">\
+              <h2 class="page-contents__title">Page contents:</h2>\
+              <ul class="page-contents__list">\
+                <li><a href="#section-1">Section 1</a></li>\
+                <li><a href="#section-2">Section 2</a></li>\
+                <li><a href="#section-3">Section 3</a></li>\
+              </ul>\
+            </div>\
+          </div>\
+          <div class="govuk-grid-column-two-thirds">\
+            <div class="govspeak-wrapper">\
+              <div class="govuk-govspeak">\
+                <h2 id="section-1">Section 1</h2>\
+                <p>Section 1 text</p>\
+                <h2 id="section-2">Section 2</h2>\
+                <p>Section 2 text</p>\
+                <h2 id="section-3">Section 3</h2>\
+                <p>Section 3 text</p>\
+              </div>\
+            </div>\
           </div>\
         </div>\
-      </div>\
-    </div>')
+        <div class="govuk-footer"></div>\
+      </div>'
+    )
+    module = new GOVUK.Modules.HighlightActiveSectionHeading($element[0])
 
     module.getWindowDimensions = function () {
       return {
@@ -41,19 +45,13 @@ describe('A highlight active section heading module', function () {
       }
     }
     module.getFooterPosition = function () {
-      return {
-        top: 500
-      }
+      return 500
     }
     module.getHeadingPosition = function () {
-      return {
-        top: 100
-      }
+      return 100
     }
     module.getNextHeadingPosition = function () {
-      return {
-        top: 200
-      }
+      return 200
     }
   })
 
@@ -69,11 +67,9 @@ describe('A highlight active section heading module', function () {
 
   it('When the page loads, it has no highlighted nav items', function () {
     module.getWindowPositions = function () {
-      return {
-        scrollTop: 0
-      }
+      return 0
     }
-    module.start($element)
+    module.init()
 
     var $anchors = $element.find('.js-page-contents a')
     expect($anchors.hasClass('active')).toBe(false)
@@ -81,11 +77,9 @@ describe('A highlight active section heading module', function () {
 
   it('When the page is scrolled, it highlights a nav item', function () {
     module.getWindowPositions = function () {
-      return {
-        scrollTop: 180
-      }
+      return 180
     }
-    module.start($element)
+    module.init()
 
     isLinkHighlighted('#section-3')
   })


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Removes jQuery from the only script in this application that uses it, `highlight-active-section-heading.js`.

This script highlights the menu item for the section of the page that is currently in view, on pages like https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction

There's a bit of clumsiness in this script where 3 functions do nothing but return the value of a new function, `getElementPosition`. I wanted to consolidate them all into one function, but the test depends on overriding these functions in order to pass. This isn't ideal, but any changes to improve this are outside of the scope of this PR.

## Why
We're removing jQuery from GOV.UK.

## Visual Changes
None.
