### PR TITLE
Making some additional changes in order to get this running as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN useradd rubytest
 
 WORKDIR /app
 
+USER rubytest
+
 RUN chown -R rubytest: /app \
     && chmod -R u+w /app
 
@@ -34,6 +36,7 @@ RUN apt-get update -qy && \
     apt-get upgrade -y && \
     apt-get install -y nodejs && \
     apt-get clean
+USER rubytest
 WORKDIR /app
 COPY --chown=rubytest --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --chown=rubytest --from=builder /app ./


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
<!-- Description of the change being made -->

Updates to add a non-root user and get the remainder of the Dockerfile running as this non-root user. Not the user has been defined as rubytest and this is a placeholder for whatever we decide on the naming convention for the user. I didn't want naming to distract from the testing here.

## Why
<!-- What are the reasons behind this change being made? -->

As part of the EKS migration - we don't want containers running as root. 

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

<!--
## Pages to check

* /service-manual/
* /service-manual/helping-people-to-use-your-service
* /service-manual/design
* /service-manual/service-assessments
* /service-manual/service-standard
* /service-manual/service-standard/point-1-understand-user-needs
* /service-manual/communities
* /service-manual/communities/accessibility-community

-->
