### PR TITLE
Change layout to fix header issue

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -7,7 +7,7 @@ class ContentItemsController < ApplicationController
   rescue_from GdsApi::HTTPForbidden, with: :error_403
 
   def show
-    slimmer_template :gem_layout_no_footer_navigation
+    slimmer_template layout
 
     if load_content_item
       set_expiry
@@ -21,6 +21,11 @@ class ContentItemsController < ApplicationController
   end
 
 private
+
+  def layout
+    paths = %w[service-manual service-toolkit]
+    paths.include?(params[:path]) ? "gem_layout_full_width_no_footer_navigation" : "gem_layout_no_footer_navigation"
+  end
 
   def load_content_item
     @content_item = present(


### PR DESCRIPTION
## What

Change the `static` layout which is used for both [The Service Manual](https://www.gov.uk/service-manual) and the [Service Toolkit](https://www.gov.uk/service-toolkit) pages.

Both pages will now use a new `static` template - `gem_layout_full_width_no_footer_navigation`. Added here: https://github.com/alphagov/static/pull/2754.

All other pages use `gem_layout_no_footer_navigation`.

## Why

To fix layout issues:

- There's a blue bar (from the footer) that's showing up in the header

## Visual Changes

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/87758239/165111985-bbf0d56b-c2e6-4f5b-9031-ff7b09667919.png" width="360"> | <img src="https://user-images.githubusercontent.com/87758239/165112167-c76103e4-6669-49fd-98ef-5a0d079dd908.png" width="360"> |
| <img src="https://user-images.githubusercontent.com/87758239/165112031-bbf84be3-3c0a-4011-aa5c-143661573d58.png" width="360"> | <img src="https://user-images.githubusercontent.com/87758239/165112212-c078aae7-0da1-42b0-9db0-baa6d85bae55.png" width="360"> |
| <img src="https://user-images.githubusercontent.com/87758239/165113382-e0c65c0e-6a8b-493a-bc36-ebe18e8062df.png" width="360"> | <img src="https://user-images.githubusercontent.com/87758239/165113464-3cb3eed2-3294-4948-8e59-96b133f7a0dc.png" width="360"> |

## Pages to check

* /service-manual/
* /service-manual/service-standard
* /service-manual/service-toolkit

## Anything else

See https://github.com/alphagov/static/pull/2719