### PR TITLE
Add Prometheus exporter for EKS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN GOVUK_APP_DOMAIN=www.gov.uk \
     bundle exec rails assets:precompile
 
 FROM $base_image
-ENV RAILS_ENV=production GOVUK_APP_NAME=service-manual-frontend
+ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=service-manual-frontend
 # bundler seems to need nodejs installed - or at least a JavaScript runtime
 RUN apt-get update -qy && \
     apt-get upgrade -y && \

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_prometheus_exporter"
+GovukPrometheusExporter.configure


### PR DESCRIPTION
Enable Prometheus exporter for EKS by:
1. adding `GOVUK_PROMETHEUS_EXPORTER=true` to Dockerfile
2. adding Prometheus initializer

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
<!-- Description of the change being made -->

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

<!--
## Pages to check

* /service-manual/
* /service-manual/helping-people-to-use-your-service
* /service-manual/design
* /service-manual/service-assessments
* /service-manual/service-standard
* /service-manual/service-standard/point-1-understand-user-needs
* /service-manual/communities
* /service-manual/communities/accessibility-community

-->
