### PR TITLE
Adding updates to the required inputs for GHA deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,15 @@ on:
         required: true
         type: string
         default: 'main'
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        type: choice
+        options:
+        - integration
+        - staging
+        - production
+        default: 'integration'
   push:
     branches:
       - main


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Add an additional environment input to the workflow dispatch in deploy.yaml with a choice input type to allow the user to select the desired environment. 

## Why
I am updating the inputs passed to the GHA workflow when run manually to allow the user to pass in the environment they want to deploy to from a dropdown. This will allow for a more seamless rollback of changes to environments other than integration.

https://trello.com/c/tUyJa4cb/923-extend-gha-to-deploy-to-specific-environment

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

<!--
## Pages to check

* /service-manual/
* /service-manual/helping-people-to-use-your-service
* /service-manual/design
* /service-manual/service-assessments
* /service-manual/service-standard
* /service-manual/service-standard/point-1-understand-user-needs
* /service-manual/communities
* /service-manual/communities/accessibility-community

-->
