### PR TITLE
Adding soft link to /tmp filesystem.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,17 @@ RUN apt-get update -qy && \
     apt-get upgrade -y && \
     apt-get install -y nodejs && \
     apt-get clean
-RUN groupadd -g 3000 appuser \
-    && useradd -u 2000 -g appuser appuser
-USER appuser
+
+RUN mkdir /app && ln -fs /tmp /app
+
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder /app /app/
+
 WORKDIR /app
-COPY --chown=appuser --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --chown=appuser --from=builder /app ./
+
+RUN groupadd -g 1001 app && \
+    useradd app -u 1001 -g 1001 --home /app
+
+USER app
+
 CMD bundle exec puma


### PR DESCRIPTION
This should allow writing to /tmp dir and fix the permission denied errors
in EKS.

This is part of non-root container work:
https://trello.com/c/Jef1t4xU/903-fix-app-permission-errors-due-to-nonroot

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
<!-- Description of the change being made -->

## Why
<!-- What are the reasons behind this change being made? -->

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

<!--
## Pages to check

* /service-manual/
* /service-manual/helping-people-to-use-your-service
* /service-manual/design
* /service-manual/service-assessments
* /service-manual/service-standard
* /service-manual/service-standard/point-1-understand-user-needs
* /service-manual/communities
* /service-manual/communities/accessibility-community

-->
