### PR TITLE
Tidy up stylesheet and JavaScript imports

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,6 @@
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/accordion
-//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/metadata
 
 //= require_tree ./modules

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,6 @@
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/accordion
 //= require govuk_publishing_components/components/button
-//= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
 
 //= require_tree ./modules

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,18 +4,9 @@ $govuk-new-link-styles: true;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/accordion";
-@import "govuk_publishing_components/components/breadcrumbs";
-@import "govuk_publishing_components/components/button";
-@import "govuk_publishing_components/components/error-message";
-@import "govuk_publishing_components/components/feedback";
 @import "govuk_publishing_components/components/govspeak";
-@import "govuk_publishing_components/components/hint";
-@import "govuk_publishing_components/components/input";
-@import "govuk_publishing_components/components/label";
 @import "govuk_publishing_components/components/metadata";
 @import "govuk_publishing_components/components/phase-banner";
-@import "govuk_publishing_components/components/search";
-@import "govuk_publishing_components/components/title";
 
 @import "mixins/margins";
 @import "mixins/print";

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -4,7 +4,6 @@ $is-print: true;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/print/accordion";
-@import "govuk_publishing_components/components/print/button";
 @import "govuk_publishing_components/components/print/govspeak";
 @import "govuk_publishing_components/components/print/title";
 


### PR DESCRIPTION
## What
<!-- Description of the change being made -->

- Remove stylesheets and JavaScript imports that are included in Static
- Update component JavaScript imports: removed button and added metadata

Reduces `application.css` from 114.56 kB to 86.75 kB uncompressed.

Reduces `application.js` from 66.31 kB to 50.38 kB uncompressed.

## Why
<!-- What are the reasons behind this change being made? -->

If CSS or JavaScript is shared across multiple rendering applications, then that code should be included in `static`'s CSS and JavaScript files. They can then be cached across a user's entire journey rather than just across the pages rendered by a single application.

The button component isn't being used by this application, so the button component JavaScript can be removed with no ill effect.

The metadata component's JavaScript wasn't being imported. Thanks to progressive enhancement this was okay and didn't pose a big problem - and including it makes sure that the metadata component works as expected.

## Visual Changes
<!-- If the change results in visual changes, show a before and after -->

None.

## Pages to check

* [live](https://gov.uk/service-manual/), [preview](https://service-manual-front-pr-1127.herokuapp.com/service-manual/)
* [live](https://gov.uk/service-manual/helping-people-to-use-your-service), [preview](https://service-manual-front-pr-1127.herokuapp.com/service-manual/helping-people-to-use-your-service)
* [live](https://gov.uk/service-manual/design), [preview](https://service-manual-front-pr-1127.herokuapp.com/service-manual/design)
* [live](https://gov.uk/service-manual/service-assessments), [preview](https://service-manual-front-pr-1127.herokuapp.com/service-manual/service-assessments)
* [live](https://gov.uk/service-manual/service-standard), [preview](https://service-manual-front-pr-1127.herokuapp.com/service-manual/service-standard)
* [live](https://gov.uk/service-manual/service-standard/), [preview](https://service-manual-front-pr-1127.herokuapp.com/service-manual/service-standard/)
* [live](https://gov.uk/service-manual/communities), [preview](https://service-manual-front-pr-1127.herokuapp.com/service-manual/communities)
* [live](https://gov.uk/service-manual/communities/accessibility-community), [preview](https://service-manual-front-pr-1127.herokuapp.com/service-manual/communities/accessibility-community)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
