### PR TITLE
Turn off font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,11 @@ $govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
+// This flag stops the font from being included in this application's
+// stylesheet - the font is being served by Static across all of GOV.UK, so is
+// not needed here.
+$govuk-include-default-font-face: false;
+
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/accordion";
 @import "govuk_publishing_components/components/govspeak";


### PR DESCRIPTION
## What

Prevent the font from being included in `service-manual-frontend`'s stylesheet.

## Why

We should be serving the font files from `static` so they're cached across the entirety of GOVUK - so the font shouldn't be included in `service-manual-frontend`'s stylesheet.

With the font being served by each application, users need to re-download it every time they went from a page rendered in one application to a page rendered in another application.

Serving it from `static` means that the same font URI is used in each application, allowing the fonts to be cached and reused.

## Visual changes

None - the same font is being served from `static`, instead of `service-manual-frontend`.

Before (the font paths contains `service-manual-frontend`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181234300-8604f62d-fdad-4aaa-8c28-145ea8bdbf6b.png">

After (the font path contains `static`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181234333-2bb51126-0fbd-46c8-8afa-542a30d402f5.png">

---

## Search page examples to sanity check:

- https://service-manual-front-pr-1144.herokuapp.com/service-manual