### PR TITLE
Add GA4 accordion tracking

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -50,8 +50,18 @@ class TopicPresenter < ContentItemPresenter
     # This method returns the content in the required shape from the hash
     # supplied by the `groups` method.
 
-    groups.map do |section|
+    groups.each.with_index(1).map do |section, index|
       {
+        data_attributes: {
+          module: "gtm-track-click",
+          ga4: {
+            event_name: "select_content",
+            type: "accordion",
+            text: section.name,
+            index: index,
+            index_total: groups.length,
+          },
+        },
         heading: {
           text: section.name,
         },

--- a/app/views/content_items/topic.html.erb
+++ b/app/views/content_items/topic.html.erb
@@ -26,8 +26,21 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if @content_item.display_as_accordion? %>
+        <% items = @content_item.accordion_content %>
+        <%
+          ga4_attributes = {
+            event_name: "select_content",
+            type: "accordion",
+            text: "Show all sections",
+            index: 0,
+            index_total: items.length,
+          }
+        %>
         <%= render "govuk_publishing_components/components/accordion", {
-          items: @content_item.accordion_content
+          data_attributes_show_all: {
+            "ga4": ga4_attributes.to_json
+          },
+          items: items,
         } %>
       <% else %>
         <% @content_item.groups.each_with_index do |link_group| %>

--- a/test/presenters/topic_presenter_test.rb
+++ b/test/presenters/topic_presenter_test.rb
@@ -29,6 +29,16 @@ class TopicPresenterTest < ActiveSupport::TestCase
   test "returns accordion content data" do
     accordion_content = presented_topic.accordion_content
     first_accordion_section = {
+      data_attributes: {
+        module: "gtm-track-click",
+        ga4: {
+          event_name: "select_content",
+          type: "accordion",
+          text: "Group 1",
+          index: 1,
+          index_total: 2,
+        },
+      },
       heading: { text: "Group 1" },
       summary: { text: "The first group" },
       content: { html: "<ul class=\"govuk-list\">\n<li><a class=\"govuk-link\" href=\"/service-manual/user-centred-design/accessibility\">Accessibility</a></li>\n<li><a class=\"govuk-link\" href=\"/service-manual/user-centred-design/resources/patterns/addresses\">Addresses</a></li>\n</ul>" },


### PR DESCRIPTION
We are currently working to complete the implementation of GA4 tracking on all accordions, across all frontend apps.

This PR adds tracking to the accordions on the following page:
- [x] [/app/views/content_items/topic.html.erb](https://github.com/alphagov/service-manual-frontend/blob/main/app/views/content_items/topic.html.erb)

Example URL(s):
- https://www.gov.uk/service-manual/agile-delivery
- https://www.gov.uk/service-manual/helping-people-to-use-your-service
- https://www.gov.uk/service-manual/user-research
- https://www.gov.uk/service-manual/technology

[Trello](https://trello.com/c/0gjuZZxe/344-complete-the-implementation-of-ga4-accordions-on-all-frontend-apps)

## Visual Changes
None

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️