### PR TITLE
Remove the show all title from accordion GA4 tracking

### DIFF
--- a/app/views/content_items/topic.html.erb
+++ b/app/views/content_items/topic.html.erb
@@ -31,7 +31,6 @@
           ga4_attributes = {
             event_name: "select_content",
             type: "accordion",
-            text: "Show all sections",
             index: 0,
             index_total: items.length,
           }


### PR DESCRIPTION
## What

Remove the title from the GA4 tracking on accordions

## Why

The title is automatically supplied by the tracking script, so passing it in directly is no longer required.

## Visual Changes

None

[Trello](https://trello.com/c/0gjuZZxe/344-complete-the-implementation-of-ga4-accordions-on-all-frontend-apps)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
