### PR TITLE
Rename GA4 tracking module

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -53,7 +53,7 @@ class TopicPresenter < ContentItemPresenter
     groups.each.with_index(1).map do |section, index|
       {
         data_attributes: {
-          module: "gtm-track-click",
+          module: "ga4-event-tracker",
           ga4: {
             event_name: "select_content",
             type: "accordion",

--- a/test/presenters/topic_presenter_test.rb
+++ b/test/presenters/topic_presenter_test.rb
@@ -30,7 +30,7 @@ class TopicPresenterTest < ActiveSupport::TestCase
     accordion_content = presented_topic.accordion_content
     first_accordion_section = {
       data_attributes: {
-        module: "gtm-track-click",
+        module: "ga4-event-tracker",
         ga4: {
           event_name: "select_content",
           type: "accordion",


### PR DESCRIPTION
## What

Rename the GA4 tracking module to `ga4-event-tracker`.

## Why

The GA4 tracking module [has been renamed to `ga4-event-tracker`](https://github.com/alphagov/govuk_publishing_components/pull/2906).

[Trello](https://trello.com/c/0gjuZZxe/344-complete-the-implementation-of-ga4-accordions-on-all-frontend-apps)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️