### PR TITLE
Accordion show/hide all sections not working on topic pages

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -53,7 +53,6 @@ class TopicPresenter < ContentItemPresenter
     groups.each.with_index(1).map do |section, index|
       {
         data_attributes: {
-          module: "ga4-event-tracker",
           ga4: {
             event_name: "select_content",
             type: "accordion",

--- a/app/views/content_items/topic.html.erb
+++ b/app/views/content_items/topic.html.erb
@@ -36,6 +36,9 @@
           }
         %>
         <%= render "govuk_publishing_components/components/accordion", {
+          data_attributes: {
+            module: "ga4-event-tracker",
+          },
           data_attributes_show_all: {
             "ga4": ga4_attributes.to_json
           },

--- a/test/presenters/topic_presenter_test.rb
+++ b/test/presenters/topic_presenter_test.rb
@@ -30,7 +30,6 @@ class TopicPresenterTest < ActiveSupport::TestCase
     accordion_content = presented_topic.accordion_content
     first_accordion_section = {
       data_attributes: {
-        module: "ga4-event-tracker",
         ga4: {
           event_name: "select_content",
           type: "accordion",


### PR DESCRIPTION
## What 

Add the `module` to the `data_attributes` hash within the accordion component.

## Why 

The `Show/hide all sections` part of the accordion on the manuals pages is not being tracked and the `dataLayer` push is not firing.

## Visual Changes

None 

[Trello](https://trello.com/c/PiCNfSZq/374-datalayer-push-not-functioning-on-some-show-hide-all-sections-accordion-interactions)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️