### PR TITLE
Replace obsolete govuk-content-schema-test-helpers with govuk-schemas.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ end
 
 group :test do
   gem "capybara"
-  gem "govuk-content-schema-test-helpers"
+  gem "govuk_schemas"
   gem "pry-byebug"
   gem "rails-controller-testing"
   gem "simplecov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,8 +117,6 @@ GEM
       rest-client (~> 2.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_app_config (4.9.0)
       logstasher (~> 2.1)
       plek (~> 4)
@@ -140,6 +138,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+    govuk_schemas (4.4.1)
+      json-schema (~> 2.8.0)
     govuk_test (3.0.1)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
@@ -386,9 +386,9 @@ DEPENDENCIES
   binding_of_caller
   capybara
   gds-api-adapters
-  govuk-content-schema-test-helpers
   govuk_app_config
   govuk_publishing_components
+  govuk_schemas
   govuk_test
   listen
   plek

--- a/test/integration/topic_test.rb
+++ b/test/integration/topic_test.rb
@@ -2,12 +2,7 @@ require "test_helper"
 
 class TopicTest < ActionDispatch::IntegrationTest
   setup do
-    @topic_example = JSON.parse(
-      GovukContentSchemaTestHelpers::Examples.new.get(
-        "service_manual_topic",
-        "service_manual_topic",
-      ),
-    )
+    @topic_example = GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic")
   end
 
   test "it uses topic description as meta description" do

--- a/test/presenters/guide_presenter_test.rb
+++ b/test/presenters/guide_presenter_test.rb
@@ -35,12 +35,9 @@ class GuidePresenterTest < ActiveSupport::TestCase
   end
 
   test "#category_title is the title of the parent for a point" do
-    example = GovukContentSchemaTestHelpers::Examples.new.get(
-      "service_manual_guide",
-      "point_page",
-    )
+    example = GovukSchemas::Example.find("service_manual_guide", example_name: "point_page")
 
-    presenter = GuidePresenter.new(JSON.parse(example))
+    presenter = GuidePresenter.new(example)
 
     assert presenter.category_title, "The Service Standard"
   end
@@ -154,7 +151,7 @@ private
 
   def presented_guide(overriden_attributes = {}, example = "service_manual_guide")
     GuidePresenter.new(
-      JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get("service_manual_guide", example)).merge(overriden_attributes),
+      GovukSchemas::Example.find("service_manual_guide", example_name: example).merge(overriden_attributes),
     )
   end
 end

--- a/test/presenters/homepage_presenter_test.rb
+++ b/test/presenters/homepage_presenter_test.rb
@@ -26,9 +26,7 @@ private
 
   def presented_homepage(overriden_attributes = {})
     HomepagePresenter.new(
-      JSON.parse(
-        GovukContentSchemaTestHelpers::Examples.new.get("service_manual_homepage", "service_manual_homepage"),
-      ).merge(overriden_attributes),
+      GovukSchemas::Example.find("service_manual_homepage", example_name: "service_manual_homepage").merge(overriden_attributes),
     )
   end
 end

--- a/test/presenters/service_standard_presenter_test.rb
+++ b/test/presenters/service_standard_presenter_test.rb
@@ -73,13 +73,9 @@ class ServiceStandardPresenterTest < ActiveSupport::TestCase
 private
 
   def presented_standard(overriden_attributes = {})
-    example = GovukContentSchemaTestHelpers::Examples.new.get(
-      "service_manual_service_standard",
-      "service_manual_service_standard",
-    )
+    example = GovukSchemas::Example.find("service_manual_service_standard", example_name: "service_manual_service_standard")
 
-    example_with_overrides = JSON.parse(example)
-      .merge(overriden_attributes.with_indifferent_access)
+    example_with_overrides = example.merge(overriden_attributes.with_indifferent_access)
 
     ServiceStandardPresenter.new(example_with_overrides)
   end

--- a/test/presenters/topic_presenter_test.rb
+++ b/test/presenters/topic_presenter_test.rb
@@ -90,9 +90,8 @@ class TopicPresenterTest < ActiveSupport::TestCase
 private
 
   def presented_topic(overriden_attributes = {})
-    parsed = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get("service_manual_topic", "service_manual_topic"))
     TopicPresenter.new(
-      parsed.merge(overriden_attributes.with_indifferent_access),
+      GovukSchemas::Example.find("service_manual_topic", example_name: "service_manual_topic").merge(overriden_attributes.with_indifferent_access),
     )
   end
 end

--- a/test/support/govuk_content_schema_examples.rb
+++ b/test/support/govuk_content_schema_examples.rb
@@ -12,11 +12,6 @@ require "gds_api/test_helpers/content_store"
 # Including this module will automatically stub out all the available examples
 # with the content store.
 
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "frontend"
-  config.project_root = Rails.root
-end
-
 module GovukContentSchemaExamples
   extend ActiveSupport::Concern
 
@@ -31,16 +26,12 @@ module GovukContentSchemaExamples
   end
 
   def govuk_content_schema_example(schema_name, example_name, overrides = {})
-    JSON.parse(
-      GovukContentSchemaTestHelpers::Examples.new.get(schema_name, example_name),
-    ).deep_merge(overrides.stringify_keys)
+    GovukSchemas::Example.find(schema_name, example_name: example_name).deep_merge(overrides.stringify_keys)
   end
 
   module ClassMethods
     def all_examples_for_supported_formats
-      GovukContentSchemaTestHelpers::Examples.new.get_all_for_formats(supported_formats).map do |string|
-        JSON.parse(string)
-      end
+      supported_formats.map { |format| GovukSchemas::Example.find_all(format) }.flatten
     end
 
     def supported_formats


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove the obsolete govuk-content-schema-test-helpers gem and replace with govuk_schemas.

## Why
Old gem is obsolete and archived, we should not be using: https://trello.com/c/b9PRFqgU/231-applications-use-govuk-content-schema-test-helpers-which-is-an-archived-gem

## Visual Changes
No visual changes (only affects test suite).
