### PR TITLE
Update GA4 accordion tracking

### DIFF
--- a/app/views/content_items/topic.html.erb
+++ b/app/views/content_items/topic.html.erb
@@ -27,21 +27,8 @@
     <div class="govuk-grid-column-two-thirds">
       <% if @content_item.display_as_accordion? %>
         <% items = @content_item.accordion_content %>
-        <%
-          ga4_attributes = {
-            event_name: "select_content",
-            type: "accordion",
-            index: 0,
-            index_total: items.length,
-          }
-        %>
         <%= render "govuk_publishing_components/components/accordion", {
-          data_attributes: {
-            module: "ga4-event-tracker",
-          },
-          data_attributes_show_all: {
-            "ga4": ga4_attributes.to_json
-          },
+          ga4_tracking: true,
           items: items,
         } %>
       <% else %>


### PR DESCRIPTION
**NOT TO BE MERGED unless also including the [new version of the components gem](https://github.com/alphagov/govuk_publishing_components/pull/3091) that includes the changes detailed below**

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- ahead of a change to how tracking and accordion tracking works, update accordions to have the simpler `ga4_tracking:true` option instead of passing multiple data attributes

Page where the accordion appears: https://www.gov.uk/service-manual/helping-people-to-use-your-service

## Why
We've been changing how tracking works a little, specifically in https://github.com/alphagov/govuk_publishing_components/pull/3082 and this PR updates to take account of that change.


## Visual Changes
None.

Trello card: https://trello.com/c/LIhvDkyC/279-simplify-adding-ga4-tracking-to-accordions